### PR TITLE
Incoming Damage Reductions

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/commands/TownyCombatAdminCommand.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/commands/TownyCombatAdminCommand.java
@@ -67,7 +67,7 @@ public class TownyCombatAdminCommand implements TabExecutor {
 
 	private void showHelp(CommandSender sender) {
 		sender.sendMessage(ChatTools.formatTitle("/townycombatadmin"));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/tca", "reload", Translatable.of("admin_help_reload").forLocale(sender)));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/tcm", "reload", Translatable.of("admin_help_reload").forLocale(sender)));
 	}
 
 	private void parseReloadCommand(CommandSender sender) {

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -10,10 +10,9 @@ import io.github.townyadvanced.townycombat.utils.TownyCombatMovementUtil;
 
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
@@ -91,12 +90,21 @@ public class TownyCombatBukkitEventListener implements Listener {
 		TownyCombatMovementUtil.adjustPlayerAndMountSpeeds(event.getPlayer());
 	}
 
-    @EventHandler (ignoreCancelled = true)
-    public void on (EntityDamageByEntityEvent event) {
-		if(event.getDamager() instanceof Player
-			|| (event.getDamager() instanceof Projectile
-				&& ((Projectile)event.getDamager()).getShooter() instanceof Player)) {
-			event.setDamage(event.getDamage() + (event.getDamage() * (TownyCombatSettings.getDamageModificationAllWeaponsPercentage() / 100)));
+	@EventHandler (ignoreCancelled = true)
+    public void on (EntityDamageEvent event) {
+		if(event.getEntity() instanceof Player) {
+			//Reduce damage to players
+			event.setDamage(event.getDamage() + (event.getDamage() * (TownyCombatSettings.getDamageAdjustmentsPlayersIncoming() / 100)));
+
+		} else if (event.getEntity() instanceof AbstractHorse) {
+			//Reduce damage to horses
+			if(TownyCombatSettings.getDamageAdjustmentsHorsesImmuneToFire()
+					&& (event.getCause() == EntityDamageEvent.DamageCause.FIRE
+					|| event.getCause() == EntityDamageEvent.DamageCause.FIRE_TICK)) {
+				event.setCancelled(true);
+			} else {
+				event.setDamage(event.getDamage() + (event.getDamage() * (TownyCombatSettings.getDamageAdjustmentsHorsesIncoming() / 100)));
+			}
 		}
 	}
 }

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -165,12 +165,24 @@ public enum ConfigNodes {
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
-	DAMAGE_ADJUSTMENTS_ALL_WEAPONS_PERCENTAGE(
-			"damage_adjustments.all_weapons_percentage",
+	DAMAGE_ADJUSTMENTS_PLAYERS_INCOMING(
+			"damage_adjustments.players_incoming",
 			"-30",
 			"",
-			"# This setting adjusts the damage of all weapons (including fists)",
+			"# This setting adjusts the incoming damage to all players.",
 			"# TIP: If armour slowing is enabled, this setting is important, as players will generally have less armour."),
+	DAMAGE_ADJUSTMENTS_HORSES_INCOMING(
+			"damage_adjustments.horses_incoming",
+			"-50",
+			"",
+			"# This setting adjusts the incoming damage to all horses.",
+			"# TIP: This setting is important to make horses viable in battle."),
+	DAMAGE_ADJUSTMENTS_HORSES_IMMUNE_TO_FIRE(
+			"damage_adjustments.horses_immune_to_fire",
+			"true",
+			"",
+			"# If this setting is true, then horses are immune to fire damage.",
+			"# TIP: This setting is important to make horses viable in battle."),
 	SPEED_ADJUSTMENTS(
 			"speed_adjustments",
 			"",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -173,7 +173,7 @@ public enum ConfigNodes {
 			"# TIP: If armour slowing is enabled, this setting is important, as players will generally have less armour."),
 	DAMAGE_ADJUSTMENTS_HORSES_INCOMING(
 			"damage_adjustments.horses_incoming",
-			"-80",
+			"-90",
 			"",
 			"# This setting adjusts the incoming damage to all horses.",
 			"# TIP: This setting is important to make horses viable in battle."),

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -173,7 +173,7 @@ public enum ConfigNodes {
 			"# TIP: If armour slowing is enabled, this setting is important, as players will generally have less armour."),
 	DAMAGE_ADJUSTMENTS_HORSES_INCOMING(
 			"damage_adjustments.horses_incoming",
-			"-50",
+			"-80",
 			"",
 			"# This setting adjusts the incoming damage to all horses.",
 			"# TIP: This setting is important to make horses viable in battle."),

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -256,8 +256,16 @@ public class TownyCombatSettings {
 		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_GENERIC_CAVALRY_ADJUSTMENT_PERCENTAGE);
 	}
 
-	public static double getDamageModificationAllWeaponsPercentage() {
-		return Settings.getDouble(ConfigNodes.DAMAGE_ADJUSTMENTS_ALL_WEAPONS_PERCENTAGE);
+	public static double getDamageAdjustmentsPlayersIncoming() {
+		return Settings.getDouble(ConfigNodes.DAMAGE_ADJUSTMENTS_PLAYERS_INCOMING);
+	}
+
+	public static double getDamageAdjustmentsHorsesIncoming() {
+		return Settings.getDouble(ConfigNodes.DAMAGE_ADJUSTMENTS_HORSES_INCOMING);
+	}
+
+	public static boolean getDamageAdjustmentsHorsesImmuneToFire() {
+		return Settings.getBoolean(ConfigNodes.DAMAGE_ADJUSTMENTS_HORSES_IMMUNE_TO_FIRE);
 	}
 	
 	public static double getCavalryEncumbranceReductionPercentage() {


### PR DESCRIPTION
#### Description: 
This PR contains
- Updated the weapon damage reduction to incoming player damage reduction, to more properly compensate for reduced armour.
- Added incoming horse damage reduction (makes them about 1.5 times as tough as players when each is fully armoured)
- Made horses immune to fire (Because if they are on fire they are useless in combat due to rearing up)

____
#### New Nodes/Commands/ConfigOptions: 
```
############################################################
# +------------------------------------------------------+ #
# |                 DAMAGE ADJUSTMENTS                   | #
# +------------------------------------------------------+ #
############################################################
  
damage_adjustments:
  
  # This setting adjusts the incoming damage to all players.
  # TIP: If armour slowing is enabled, this setting is important, as players will generally have less armour.
  players_incoming: '-30'
  
  # This setting adjusts the incoming damage to all horses.
  # TIP: This setting is important to make horses viable in battle.
  horses_incoming: '-90'
  
  # If this setting is true, then horses are immune to fire damage.
  # TIP: This setting is important to make horses viable in battle.
  horses_immune_to_fire: 'true'
  
```
____
#### Relevant Issue ticket:
N/A

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyCombat [License](https://github.com/TownyAdvanced/TownyCombat/blob/master/LICENSE.md) for perpetuity.
