### PR TITLE
Add special chest weights

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -258,6 +258,14 @@ public enum ConfigNodes {
 			"speed_adjustments.encumbrance.infantry.base_item_percentage.warhammer",
 			"12",
 			""),
+	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX(
+			"speed_adjustments.encumbrance.infantry.base_item_percentage.shulker_box",
+			"15",
+			""),
+	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST(
+			"speed_adjustments.encumbrance.infantry.base_item_percentage.ender_chest",
+			"30",
+			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET(
 			"speed_adjustments.encumbrance.infantry.base_item_percentage.helmet",
 			"0.6",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -113,6 +113,26 @@ public class TownyCombatSettings {
 		materialEncumbrancePercentageMap.put(Material.SHIELD, getEquipmentEncumbranceShield());
 		materialEncumbrancePercentageMap.put(TownyCombatItemUtil.SPEAR_PLACEHOLDER_MATERIAL, getEquipmentEncumbranceSpear());
 		materialEncumbrancePercentageMap.put(TownyCombatItemUtil.WARHAMMER_PLACEHOLDER_MATERIAL, getEquipmentEncumbranceWarhammer());
+
+		//Enderchest & shulker boxes
+		materialEncumbrancePercentageMap.put(Material.ENDER_CHEST, getEquipmentEncumbranceEnderChest());
+		materialEncumbrancePercentageMap.put(Material.SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.BLACK_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.BLUE_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.BROWN_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.CYAN_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.GRAY_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.GREEN_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.LIGHT_BLUE_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.LIGHT_GRAY_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.LIME_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.MAGENTA_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.ORANGE_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.PINK_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.PURPLE_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.RED_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.WHITE_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
+		materialEncumbrancePercentageMap.put(Material.YELLOW_SHULKER_BOX, getEquipmentEncumbranceShulkerBox());
 	}
 
 	public static boolean isTownyCombatEnabled() {
@@ -291,4 +311,11 @@ public class TownyCombatSettings {
 		return Settings.getBoolean(ConfigNodes.NEW_ITEMS_WARHAMMER_ENABLED);
 	}
 
+	public static double getEquipmentEncumbranceShulkerBox() {
+		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX);
+	}
+
+	public static double getEquipmentEncumbranceEnderChest() {
+		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST);
+	}
 }


### PR DESCRIPTION
#### Description:
- With current code, enderchests and shulker boxes can be used for an individual soldier to easily being many more potions into battles.
- This PR makes it much more difficult, by giving encumbrance to enderchests and shulker boxes.

____
#### New Nodes/Commands/ConfigOptions: 
```
	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX(
			"speed_adjustments.encumbrance.infantry.base_item_percentage.shulker_box",
			"15",
			""),
	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST(
			"speed_adjustments.encumbrance.infantry.base_item_percentage.ender_chest",
			"30",
			""),
```
____
#### Relevant Issue ticket:
Closes #14 
____
- [ N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyCombat [License](https://github.com/TownyAdvanced/TownyCombat/blob/master/LICENSE.md) for perpetuity.