### PR TITLE
Fix jump damager

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -297,7 +297,7 @@ public enum ConfigNodes {
 			"speed_adjustments.encumbrance.infantry.base_percentage.helmet",
 			"0.6",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_CHESTPLATE(
+	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE(
 			"speed_adjustments.encumbrance.infantry.base_percentage.chestplate",
 			"1.6",
 			""),
@@ -320,19 +320,19 @@ public enum ConfigNodes {
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL(
 			"speed_adjustments.encumbrance.infantry.modification_percentage.chainmail",
-			"180",
+			"200",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL(
 			"speed_adjustments.encumbrance.infantry.modification_percentage.turtle_shell",
-			"260",
+			"300",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD(
 			"speed_adjustments.encumbrance.infantry.modification_percentage.gold",
-			"340",
+			"300",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON(
 			"speed_adjustments.encumbrance.infantry.modification_percentage.iron",
-			"420",
+			"400",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND(
 			"speed_adjustments.encumbrance.infantry.modification_percentage.diamond",
@@ -357,7 +357,7 @@ public enum ConfigNodes {
 			"8",
 			"",
 			"# Players only take jump damage when their encumbrance is above this threshold.",
-			"# TIP: With default settings, jump damage will only apply to players carrying something heavier than a full chain-mail set."),
+			"# TIP: With default settings, jump damage will only apply to players carrying the equivalent of a full chain-mail set or heavier."),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT(
 			"speed_adjustments.encumbrance.infantry.jump_damage.damage_per_encumbrance_percent",
 			"0.07",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -49,27 +49,27 @@ public enum ConfigNodes {
 			"",
 			"",
 			"# +------------------------------------------------------+ #",
-			"# |                   CAVALRY CHARGE                     | #",
+			"# |                 CAVALRY DAMAGE BONUS                 | #",
 			"# +------------------------------------------------------+ #",
 			""),
 	HORSE_ENHANCEMENTS_CAVALRY_CHARGE_ENABLED(
-			"horse_enhancements.cavalry_charge.enabled",
+			"horse_enhancements.cavalry_damage_bonus.enabled",
 			"true",
 			"",
-			"# If this setting is true, then the Cavalry Charge ability is enabled:",
+			"# If this setting is true, then the Cavalry Damage Bonus is enabled:",
 			"# - Starts in cooldown when a player mounts a horse.",
-			"# - Goes into cooldown when the rider strikes a player/mob with their weapon.",
+			"# - Goes into cooldown when the rider strikes a player/mob with their weapon. (melee or missile)",
 			"# - Effect: Strength"),
 	HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_EFFECT_LEVEL(
-			"horse_enhancements.cavalry_charge.effect_level",
+			"horse_enhancements.cavalry_damage_bonus.effect_level",
 			"2",
 			"",
-			"# The level of the strength effect."),
+			"# The level of the bonus strength effect."),
 	HORSE_ENHANCEMENTS_CAVALRY_CHARGE_COOLDOWN_SECONDS(
-			"horse_enhancements.cavalry_charge.cooldown_time_seconds",
-			"15",
+			"horse_enhancements.cavalry_damage_bonus.cooldown_time_seconds",
+			"12",
 			"",
-			"# The charge effect cooldown."),
+			"# The damage bonus cooldown."),
 	BLOCK_GLITCHING_PREVENTION(
 		"block_glitching_prevention",
 			"",
@@ -227,13 +227,13 @@ public enum ConfigNodes {
 			"",
 			""),
 	SPEED_ADJUSTMENTS_GENERIC_INFANTRY_ADJUSTMENT_PERCENTAGE(
-			"speed_adjustments.generic.infantry_adjustment_percent",
+			"speed_adjustments.generic.infantry_adjust_percent",
 			"12",
 			"",
 			"# Adjusts the walking speed of all players.",
 			"# TIP: Giving all players a small speed boost helps sugar-coat the concept of encumbrance."),
 	SPEED_ADJUSTMENTS_GENERIC_CAVALRY_ADJUSTMENT_PERCENTAGE(
-			"speed_adjustments.generic.cavalry_adjustment_percent",
+			"speed_adjustments.generic.cavalry_adjust_percent",
 			"12",
 			"",
 			"# Adjusts the walking speed of all player mounts.",
@@ -261,85 +261,85 @@ public enum ConfigNodes {
 			"# +------------------------------------------------------+ #",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE(
-			"speed_adjustments.infantry.armour_slowing.base_item_percent",
+			"speed_adjustments.encumbrance.infantry.base_percentage",
 			"",
 			"",
-			"# The base slow percentage for each type of armour item."),
+			"# The base slow percentage for each type of item."),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOW(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.bow",
+			"speed_adjustments.encumbrance.infantry.base_percentage.bow",
 			"3",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHIELD(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.shield",
+			"speed_adjustments.encumbrance.infantry.base_percentage.shield",
 			"4",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SPEAR(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.spear",
+			"speed_adjustments.encumbrance.infantry.base_percentage.spear",
 			"5",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CROSSBOW(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.crossbow",
+			"speed_adjustments.encumbrance.infantry.base_percentage.crossbow",
 			"6",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_WARHAMMER(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.warhammer",
+			"speed_adjustments.encumbrance.infantry.base_percentage.warhammer",
 			"12",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.shulker_box",
+			"speed_adjustments.encumbrance.infantry.base_percentage.shulker_box",
 			"15",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.ender_chest",
+			"speed_adjustments.encumbrance.infantry.base_percentage.ender_chest",
 			"30",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.helmet",
+			"speed_adjustments.encumbrance.infantry.base_percentage.helmet",
 			"0.6",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_CHESTPLATE(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.chestplate",
+			"speed_adjustments.encumbrance.infantry.base_percentage.chestplate",
 			"1.6",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_LEGGINGS(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.leggings",
+			"speed_adjustments.encumbrance.infantry.base_percentage.leggings",
 			"1.2",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOOTS(
-			"speed_adjustments.encumbrance.infantry.base_item_percent.boots",
+			"speed_adjustments.encumbrance.infantry.base_percentage.boots",
 			"0.6",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent",
+			"speed_adjustments.encumbrance.infantry.modification_percentage",
 			"",
 			"",
 			"# The modification to encumbrance, of each material."),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_LEATHER(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.leather",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.leather",
 			"100",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.chainmail",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.chainmail",
 			"180",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.turtle_shell",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.turtle_shell",
 			"260",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.gold",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.gold",
 			"340",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.iron",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.iron",
 			"420",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.diamond",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.diamond",
 			"500",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_NETHERITE(
-			"speed_adjustments.encumbrance.infantry.material_modification_percent.netherite",
+			"speed_adjustments.encumbrance.infantry.modification_percentage.netherite",
 			"600",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE(
@@ -350,8 +350,8 @@ public enum ConfigNodes {
 			"speed_adjustments.encumbrance.infantry.jump_damage.enabled",
 			"true",
 			"",
-			"# If enabled, player with heavy armour take a little damage when they jump or ascend an incline.",
-			"# TIP: This setting stop players from exploiting/encumbrance-bypassing by 'bunny hopping' their way all over the battleield."),
+			"# If enabled, player with heavy armour sometimes take damage when they jump or ascend an incline.",
+			"# TIP: This setting stop players from exploiting/encumbrance-bypassing by 'bunny hopping' their way all over the battlefield."),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD(
 			"speed_adjustments.encumbrance.infantry.jump_damage.threshold",
 			"8",
@@ -360,7 +360,7 @@ public enum ConfigNodes {
 			"# TIP: With default settings, jump damage will only apply to players carrying something heavier than a full chain-mail set."),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT(
 			"speed_adjustments.encumbrance.infantry.jump_damage.damage_per_encumbrance_percent",
-			"0.03",
+			"0.07",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY(
 			"speed_adjustments.encumbrance.cavalry",
@@ -377,24 +377,24 @@ public enum ConfigNodes {
 			"",
 			"# Horses, being stronger, can carry more weight, thus their encumbrance is reduced"),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE(
-			"speed_adjustments.encumbrance.cavalry.item_percent",
+			"speed_adjustments.encumbrance.cavalry.percentage",
 			"",
 			"",
 			"# The slow percentage for each type of cavalry armour item."),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_LEATHER_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.item_percent.leather_horse_armour",
+			"speed_adjustments.encumbrance.cavalry.percentage.leather_horse_armour",
 			"8",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_GOLD_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.item_percent.gold_horse_armour",
+			"speed_adjustments.encumbrance.cavalry.percentage.gold_horse_armour",
 			"27",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_IRON_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.item_percent.iron_horse_armour",
+			"speed_adjustments.encumbrance.cavalry.percentage.iron_horse_armour",
 			"34",
 			""),
 	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_DIAMOND_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.item_percent.diamond_horse_armour",
+			"speed_adjustments.encumbrance.cavalry.percentage.diamond_horse_armour",
 			"40",
 			""),
 	NEW_ITEMS(

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -218,7 +218,7 @@ public class TownyCombatSettings {
 	}
 	
 	public static double getEquipmentEncumbranceBaseChestplate() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_CHESTPLATE);
+		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE);
 	}
 	
 	public static double getEquipmentEncumbranceBaseLeggings() {

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -9,13 +9,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -182,10 +181,11 @@ public class TownyCombatMovementUtil {
                     || player.isInvulnerable()) {                
                 continue;
             }
-            if(!player.isOnGround)
-                continue;
             velocityY = player.getVelocity().getY();  
-            if(velocityY != GRAVITY_VELOCITY && velocityY != LADDER_VELOCITY && velocityY > 0) {
+            if(velocityY != GRAVITY_VELOCITY 
+                    && velocityY != LADDER_VELOCITY 
+                    && velocityY > 0
+                    && player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType() == Material.AIR) {
                 /*
                  * Player is jumping or ascending an incline
                  *

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -192,9 +192,9 @@ public class TownyCombatMovementUtil {
                  */
                 playerEncumbrancePercentage = playerEncumbrancePercentageMap.get(player);
                 if(playerEncumbrancePercentage != null && playerEncumbrancePercentage > JUMP_DAMAGE_THRESHOLD) {
-                    damage = playerEncumbrancePercentage * JUMP_DAMAGE_PER_ENCUMBRANCE_PERCENT;
-                    final double newHealth = Math.max(0, player.getHealth() - damage);
-                    TownyCombat.getPlugin().getServer().getScheduler().runTask(TownyCombat.getPlugin(), ()->  player.setHealth(newHealth));
+                    newHealth = player.getHealth() - (playerEncumbrancePercentage * JUMP_DAMAGE_PER_ENCUMBRANCE_PERCENT);
+                    final double finalNewHealth = Math.max(0, Math.min(player.getAttribute(Attribute.GENERIC_HEALTH).getBaseValue()); //apply min and max
+                    TownyCombat.getPlugin().getServer().getScheduler().runTask(TownyCombat.getPlugin(), ()->  player.setHealth(finalNewHealth));
                }
             }
         }

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -192,7 +192,7 @@ public class TownyCombatMovementUtil {
                 playerEncumbrancePercentage = playerEncumbrancePercentageMap.get(player);
                 if(playerEncumbrancePercentage != null && playerEncumbrancePercentage > JUMP_DAMAGE_THRESHOLD) {
                     newHealth = player.getHealth() - (playerEncumbrancePercentage * JUMP_DAMAGE_PER_ENCUMBRANCE_PERCENT);
-                    final double finalNewHealth = Math.max(0, Math.min(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()); //apply min and max
+                    final double finalNewHealth = Math.max(0, Math.min(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue(), newHealth)); //apply min and max
                     TownyCombat.getPlugin().getServer().getScheduler().runTask(TownyCombat.getPlugin(), ()->  player.setHealth(finalNewHealth));
                }
             }

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -174,8 +174,7 @@ public class TownyCombatMovementUtil {
         final double JUMP_DAMAGE_THRESHOLD = TownyCombatSettings.getJumpDamageThreshold();
         final double JUMP_DAMAGE_PER_ENCUMBRANCE_PERCENT = TownyCombatSettings.getJumpDamageDamagePerEncumbrancePercent();
         Double playerEncumbrancePercentage;
-        double velocityY;        
-        double damage;
+        double velocityY;
         double newHealth;        
         for(Player player: Bukkit.getOnlinePlayers()) {
             if(player.getGameMode() == GameMode.CREATIVE

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -182,6 +182,8 @@ public class TownyCombatMovementUtil {
                     || player.isInvulnerable()) {                
                 continue;
             }
+            if(!player.isOnGround)
+                continue;
             velocityY = player.getVelocity().getY();  
             if(velocityY != GRAVITY_VELOCITY && velocityY != LADDER_VELOCITY && velocityY > 0) {
                 /*

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -193,7 +193,7 @@ public class TownyCombatMovementUtil {
                 playerEncumbrancePercentage = playerEncumbrancePercentageMap.get(player);
                 if(playerEncumbrancePercentage != null && playerEncumbrancePercentage > JUMP_DAMAGE_THRESHOLD) {
                     newHealth = player.getHealth() - (playerEncumbrancePercentage * JUMP_DAMAGE_PER_ENCUMBRANCE_PERCENT);
-                    final double finalNewHealth = Math.max(0, Math.min(player.getAttribute(Attribute.GENERIC_HEALTH).getBaseValue()); //apply min and max
+                    final double finalNewHealth = Math.max(0, Math.min(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()); //apply min and max
                     TownyCombat.getPlugin().getServer().getScheduler().runTask(TownyCombat.getPlugin(), ()->  player.setHealth(finalNewHealth));
                }
             }


### PR DESCRIPTION
#### Description:
- With current code the jump damager code can crash if the player max health is not 20
This pr fixes the issue
- Also made the feature more robust to non-jump velocity changes by 3rd party plugins
 
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A
  
____
- [ N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyCombat [License](https://github.com/TownyAdvanced/TownyCombat/blob/master/LICENSE.md) for perpetuity.

