### PR TITLE
Stop horses getting stunned on damage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ A combat plugin for Towny, containing some fun combat/battle/pvp features.
     - Teleport with player on /n or /t spawn.
     - Speed Increase: +12%.
     - Attack Damage Resistance: +60% .
-    - Fire Shield: Immune to fire.
-    - Missile Shield: Immune to arrows from bows (but not crossbows).
+    - Missile Shield: Immune to arrows (except from crossbows).
     - Cavalry Strength Bonus: Strength 3 effect for 1 hit, cooldown for 10 seconds.
   - Special Vulnerabilities:
     - Take +9 damage when hit by a spear.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyCombat</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <name>townycombat</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -10,7 +10,9 @@ import io.github.townyadvanced.townycombat.utils.TownyCombatExperienceUtil;
 import io.github.townyadvanced.townycombat.utils.TownyCombatItemUtil;
 
 import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Arrow;
 import org.bukkit.event.EventHandler;
@@ -128,14 +130,15 @@ public class TownyCombatBukkitEventListener implements Listener {
 		if (!TownyCombatSettings.isTownyCombatEnabled())
 			return;
 		if (event.getEntity() instanceof AbstractHorse) {
-			//No fire damage to horses ridden by players
-			if(TownyCombatSettings.isCavalryFireShieldEnabled()
-                                && event.getEntity().getPassengers().size() > 0
-			        && event.getEntity().getPassengers().get(0) instanceof Player
-			        && (event.getCause() == EntityDamageEvent.DamageCause.FIRE
-				    || event.getCause() == EntityDamageEvent.DamageCause.FIRE_TICK)) {
+			//No rearing when horse is damaged. Do this by cancelling the event, then applying the same damage in a simple set operation.
+			if(TownyCombatSettings.isCavalryRearingPreventionEnabled()
+					&& event.getEntity().getPassengers().size() > 0
+			        && event.getEntity().getPassengers().get(0) instanceof Player) {
 				event.setCancelled(true);
-			} 
+				AbstractHorse horse = (AbstractHorse)event.getEntity();
+				double newHealth = horse.getHealth() - event.getDamage();
+				horse.setHealth(Math.max(0, Math.min(horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(), newHealth)));
+			}
 		}
 	}
 
@@ -200,16 +203,21 @@ public class TownyCombatBukkitEventListener implements Listener {
 			&&
 			//Cavalry Attacker 
 			(attackingPlayer != null && attackingPlayer.isInsideVehicle() && attackingPlayer.getVehicle() instanceof AbstractHorse) 				
-			&&						
-			//Infantry Victim
+			&&
+			//Infantry defender
 			(event.getEntity() instanceof Player && (!event.getEntity().isInsideVehicle() || !(event.getEntity().getVehicle() instanceof AbstractHorse)))
 			&&
 			//Bonus is charged-up
-			attackingPlayer.hasPotionEffect(PotionEffectType.INCREASE_DAMAGE)
-		) {
+			(attackingPlayer.hasPotionEffect(PotionEffectType.INCREASE_DAMAGE) && attackingPlayer.getPotionEffect(PotionEffectType.INCREASE_DAMAGE).getAmplifier() == 0))
+		{
+			/*
+			 * Note: The bonus is not already contained in the damage.
+			 * Because the str amplifier is power 0
+			 * So we need to explicitly add the damage.
+			 */
+			TownyCombatHorseUtil.registerPlayerForCavalryStrengthBonus(attackingPlayer);
 			attackingPlayer.removePotionEffect(PotionEffectType.INCREASE_DAMAGE);
 			finalDamage += (3 * TownyCombatSettings.getCavalryChargeStrengthBonusEffectLevel());
-			TownyCombatHorseUtil.registerPlayerForCavalryStrengthBonus(attackingPlayer);
 		}
 
 		//WARHAMMER: Possibly break shield

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -47,15 +47,14 @@ public enum ConfigNodes {
 			"horse_enhancements.cavalry_missile_shield_enabled",
 			"true",
 			"",
-			"# If this setting is true, then horses and riders are both shielded from arrows from player-bows",
-			"# Note that arrows fired by crossbows are not blocked.", 
+			"# If this setting is true, then horses and riders are both shielded from arrows, except from crossbows.",
 			"# TIP: This setting is essential to allow cavalry to perform the 'Tank' role, because due to lag effects, horses would otherwise be quite vulnerable to arrows."),
-	HORSE_ENHANCEMENTS_CAVALRY_FIRE_SHIELD_ENABLED(
-			"horse_enhancements.cavalry_fire_shield_enabled",
+	HORSE_ENHANCEMENTS_CAVALRY_REARING_PREVENTION_ENABLED(
+			"horse_enhancements.cavalry_rearing_prevention_enabled",
 			"true",
 			"",
-			"# If this setting is true, then horses and riders are both shielded from fire damage.",
-			"# TIP: This setting is essential to allow cavalry to perform the 'Tank' role, because due to rearing-effects, horses are useless when on fire."),
+			"# If this setting is true, then horses do not rear up when damaged.",
+			"# TIP: This setting is essential as otherwise horses become useless if set on fire, poisoned etc."),
 	HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS(
 		"horse_enhancements.cavalry_strength_bonus",
 			"",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -358,14 +358,14 @@ public class TownyCombatSettings {
 		return Settings.getDouble(ConfigNodes.AUTOPOTTING_HEALTH_THRESHOLD);
 	}
 
-	public static boolean isCavalryFireShieldEnabled() {
-		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_FIRE_SHIELD_ENABLED);
-	}
-	
 	public static boolean isCavalryMissileShieldEnabled() {
 		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_MISSILE_SHIELD_ENABLED);
 	}
 	
+	public static boolean isCavalryRearingPreventionEnabled() {
+		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_REARING_PREVENTION_ENABLED);
+	}
+
 	public static boolean isCavalryStrengthBonusEnabled() {
 		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_ENABLED);
 	}

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatHorseUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatHorseUtil.java
@@ -73,7 +73,6 @@ public class TownyCombatHorseUtil {
         long now = System.currentTimeMillis();
         long nextRefreshTime = System.currentTimeMillis() + TownyCombatSettings.getCavalryChargeCooldownMilliseconds();
         int effectDurationTicks = TownyCombatSettings.getCavalryChargeEffectDurationTicks();
-        int effectAmplifier = TownyCombatSettings.getCavalryChargeStrengthBonusEffectLevel() - 1;
 
         for(Map.Entry<Player, Long> playerTimeEntry: (new HashMap<>(cavalryStrengthBonusRefreshTimes)).entrySet()) {
             //Verify player is still on horse
@@ -83,15 +82,19 @@ public class TownyCombatHorseUtil {
             }
             if(now > playerTimeEntry.getValue()) {
                 //Refresh charge
-                TownyCombat.getPlugin().getServer().getScheduler().runTask(TownyCombat.getPlugin(), ()-> applyStrengthEffectToPlayer(playerTimeEntry.getKey(), effectDurationTicks, effectAmplifier));
+                TownyCombat.getPlugin().getServer().getScheduler().runTask(TownyCombat.getPlugin(), ()-> applyPlaceholderStrengthEffectToPlayer(playerTimeEntry.getKey(), effectDurationTicks));
                 //Arrange next refresh time
                 cavalryStrengthBonusRefreshTimes.put(playerTimeEntry.getKey(), nextRefreshTime);
             }
         }
     }
 
-    private static void applyStrengthEffectToPlayer(Player player, int effectDurationTicks, int effectAmplifier) {
-        player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, effectDurationTicks, effectAmplifier));
+    /**
+     * Apply a "placeholder" strength effect to the player
+     * This has no effect on its own, but is used to indicate the strength bonus is ready for use.
+     */
+    private static void applyPlaceholderStrengthEffectToPlayer(Player player, int effectDurationTicks) {
+        player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, effectDurationTicks,-1));
     }
 
 }


### PR DESCRIPTION
#### Description
- With current code, horses "rear up" after taking almost any sort of damage e.g hits missiles, melee, poison, wither etc. This is bad for combat usability. This PR fixes the issue - they no longer rear on damage.
- Also removed fire shield
- Also fixed a  bug where the cavalry bonus damage was getting applied twice (*Ouchey :-D*)

#### Config Nodes
```
  # If this setting is true, then horses do not rear up when damaged.
  # TIP: This setting is essential as otherwise horses become useless if set on fire, poisoned etc.
  cavalry_rearing_prevention_enabled: 'true'
  
```
____
#### Relevant Issue ticket:
Closes #31 

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyCombat [License](https://github.com/TownyAdvanced/TownyCombat/blob/master/LICENSE.md) for perpetuity.


