### PR TITLE
Horse knockback resistance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyCombat</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <name>townycombat</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -68,8 +68,8 @@ public class TownyCombatBukkitEventListener implements Listener {
 		if(!(event.getMount() instanceof AbstractHorse))
 			return;
 		//Remove modifiers if system/speed-feature is disabled		
-		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isSpeedAdjustmentsEnabled()) {
-			TownyCombatMovementUtil.removeTownyCombatMovementAttributeModifiers((AbstractHorse)event.getMount());
+		if (!TownyCombatSettings.isTownyCombatEnabled()) {
+			TownyCombatMovementUtil.removeTownyCombatMovementModifiers((AbstractHorse)event.getMount());
 		}
 		if (!TownyCombatSettings.isTownyCombatEnabled())
 			return;
@@ -116,8 +116,8 @@ public class TownyCombatBukkitEventListener implements Listener {
 		//Remove legacy data
 		TownyCombatMovementUtil.resetPlayerBaseSpeedToVanilla(event.getPlayer());
 		//Remove modifiers if system/feature is disabled
-		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isSpeedAdjustmentsEnabled()) {
-			TownyCombatMovementUtil.removeTownyCombatMovementAttributeModifiers(event.getPlayer());
+		if (!TownyCombatSettings.isTownyCombatEnabled()) {
+			TownyCombatMovementUtil.removeTownyCombatMovementModifiers(event.getPlayer());
 		} else {
 			TownyCombatMovementUtil.adjustPlayerAndMountSpeeds(event.getPlayer());
 		}
@@ -242,7 +242,7 @@ public class TownyCombatBukkitEventListener implements Listener {
 		} else if (event.getEntity() instanceof AbstractHorse) {
 			//Horse damage resistance
 			if(attackingPlayer != null) {
-				finalDamage = finalDamage - (finalDamage * (TownyCombatSettings.getDamageResistanceHorsesPercent() / 100));
+				finalDamage = finalDamage - (finalDamage * (TownyCombatSettings.getAttackDamageResistanceHorsesPercent() / 100));
 			}
 			//Auto-pot if needed
 			if(TownyCombatSettings.isAutoPottingEnabled()

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatTownyEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatTownyEventListener.java
@@ -46,14 +46,12 @@ public class TownyCombatTownyEventListener implements Listener {
 	
     @EventHandler
     public void onShortTime(NewShortTimeEvent event) {
-        if (TownyCombatSettings.isTownyCombatEnabled()) {
-        	if(TownyCombatSettings.isSpeedAdjustmentsEnabled()) {
-        		TownyCombatMovementUtil.adjustAllPlayerAndMountSpeeds();
-			}
-			if(TownyCombatSettings.isTacticalInvisibilityEnabled()) { 
-	            TownyCombatMapUtil.evaluateTacticalInvisibility();
-				TownyCombatMapUtil.applyTacticalInvisibilityToPlayers();
-			}
-        }
+        if (!TownyCombatSettings.isTownyCombatEnabled())
+        	return;
+		TownyCombatMovementUtil.adjustAllPlayerAndMountSpeeds();
+		if(TownyCombatSettings.isTacticalInvisibilityEnabled()) {
+			TownyCombatMapUtil.evaluateTacticalInvisibility();
+			TownyCombatMapUtil.applyTacticalInvisibilityToPlayers();
+		}
     }
 }

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -43,6 +43,12 @@ public enum ConfigNodes {
 			"",
 			"# This setting makes mounted-horses more resistant to attack damage from players.",
 			"# TIP: This setting is essential to make cavalry viable in battle, because in vanilla MC they are very weak."),
+	HORSE_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT(
+			"horse_enhancements.knockback_resistance_level",
+			"75",
+			"",
+			"# This setting makes mounted-horses resistant to knockback.",
+			"# TIP: This setting helps cavalry to avoid getting knocked into holes/ganks etc."),
 	HORSE_ENHANCEMENTS_CAVALRY_MISSILE_SHIELD_ENABLED(
 			"horse_enhancements.cavalry_missile_shield_enabled",
 			"true",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -19,51 +19,57 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# etc."),
-	HORSE_ENHANCEMENTS(
-		"horse_enhancements",
+	CAVALRY_ENHANCEMENTS(
+		"cavalry_enhancements",
 			"",
 			"",
 			"",
 			"############################################################",
 			"# +------------------------------------------------------+ #",
-			"# |                   HORSE ENHANCEMENTS                 | #",
+			"# |                   CAVALRY ENHANCEMENTS                 | #",
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
-	HORSE_ENHANCEMENTS_TELEPORT_MOUNT_WITH_PLAYER_ENABLED(
-			"horse_enhancements.teleport_mount_with_player_enabled",
+	CAVALRY_ENHANCEMENTS_TELEPORT_MOUNT_WITH_PLAYER_ENABLED(
+			"cavalry_enhancements.teleport_mount_with_player_enabled",
 			"true",
 			"",
 			"# If true, then when a player uses /n or /t spawn, their mount (e.g. a horse) comes with them.",
 			"# After the player spawns, the mount takes 5 seconds to arrive.",
 			"# TIP: The setting is essential to allow cavalry to get to battlefields."),
-	HORSE_ENHANCEMENTS_ATTACK_DAMAGE_RESISTANCE_PERCENT(
-			"horse_enhancements.attack_damage_resistance_percent",
+	CAVALRY_ENHANCEMENTS_GENERIC_CAVALRY_ADJUSTMENT_PERCENTAGE(
+			"cavalry_enhancements.generic_speed_adjustment_percent",
+			"12",
+			"",
+			"# Adjusts the walking speed of all player mounts.",
+			"# TIP: Giving all player mounts a small speed boost helps sugar-coat the concept of encumbrance."),
+	CAVALRY_ENHANCEMENTS_ATTACK_DAMAGE_RESISTANCE_PERCENT(
+			"cavalry_enhancements.attack_damage_resistance_percent",
 			"60",
 			"",
 			"# This setting makes mounted-horses more resistant to attack damage from players.",
 			"# TIP: This setting is essential to make cavalry viable in battle, because in vanilla MC they are very weak."),
-	HORSE_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT(
-			"horse_enhancements.knockback_resistance_level",
+	CAVALRY_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT(
+			"cavalry_enhancements.knockback_resistance_percent",
 			"75",
 			"",
 			"# This setting makes mounted-horses resistant to knockback.",
 			"# TIP: This setting helps cavalry to avoid getting knocked into holes/ganks etc."),
-	HORSE_ENHANCEMENTS_CAVALRY_MISSILE_SHIELD_ENABLED(
-			"horse_enhancements.cavalry_missile_shield_enabled",
+	CAVALRY_ENHANCEMENTS_CAVALRY_MISSILE_SHIELD_ENABLED(
+			"cavalry_enhancements.cavalry_missile_shield_enabled",
 			"true",
 			"",
 			"# If this setting is true, then horses and riders are both shielded from arrows from player-bows",
 			"# Note that arrows fired by crossbows are not blocked.", 
 			"# TIP: This setting is essential to allow cavalry to perform the 'Tank' role, because due to lag effects, horses would otherwise be quite vulnerable to arrows."),
-	HORSE_ENHANCEMENTS_CAVALRY_FIRE_SHIELD_ENABLED(
-			"horse_enhancements.cavalry_fire_shield_enabled",
+	CAVALRY_ENHANCEMENTS_CAVALRY_FIRE_SHIELD_ENABLED(
+			"cavalry_enhancements.cavalry_fire_shield_enabled",
 			"true",
 			"",
 			"# If this setting is true, then horses and riders are both shielded from fire damage.",
 			"# TIP: This setting is essential to allow cavalry to perform the 'Tank' role, because due to rearing-effects, horses are useless when on fire."),
-	HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS(
-		"horse_enhancements.cavalry_strength_bonus",
+	CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS(
+		"cavalry_enhancements.cavalry_strength_bonus",
 			"",
 			"",
 			"",
@@ -71,8 +77,8 @@ public enum ConfigNodes {
 			"# |                 CAVALRY STRENGTH BONUS               | #",
 			"# +------------------------------------------------------+ #",
 			""),
-	HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_ENABLED(
-			"horse_enhancements.cavalry_strength_bonus.enabled",
+	CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_ENABLED(
+			"cavalry_enhancements.cavalry_strength_bonus.enabled",
 			"true",
 			"",
 			"# If this setting is true, then the Cavalry Strength Bonus is enabled:",
@@ -88,16 +94,39 @@ public enum ConfigNodes {
 			"#   - Good vs infantry",
 			"#   - Counterable by other cavalry, or specialized infantry (spearmen)",
 			"#"),
-	HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_EFFECT_LEVEL(
-			"horse_enhancements.cavalry_strength_bonus.effect_level",
+	CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_EFFECT_LEVEL(
+			"cavalry_enhancements.cavalry_strength_bonus.effect_level",
 			"3",
 			"",
 			"# The level of the bonus strength effect."),
-	HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_COOLDOWN_SECONDS(
-			"horse_enhancements.cavalry_strength_bonus.cooldown_time_seconds",
+	CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_COOLDOWN_SECONDS(
+			"cavalry_enhancements.cavalry_strength_bonus.cooldown_time_seconds",
 			"10",
 			"",
 			"# The bonus effect cooldown."),
+	INFANTRY_ENHANCEMENTS(
+		"infantry_enhancements",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                   INFANTRY ENHANCEMENTS                 | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	INFANTRY_ENHANCEMENTS_GENERIC_SPEED_ADJUSTMENT_PERCENT(
+			"infantry_enhancements.generic_speed_adjustment_percent",
+			"12",
+			"",
+			"# Adjusts the walking speed of all players.",
+			"# TIP: Giving all players a small speed boost helps sugar-coat the concept of encumbrance."),
+	INFANTRY_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT(
+			"infantry_enhancements.knockback_resistance_percent",
+			"25",
+			"",
+			"# This setting makes players resistant to knockback.",
+			"# TIP: This setting helps players to avoid getting knocked into holes/ganks etc."),
 	BLOCK_GLITCHING_PREVENTION(
 		"block_glitching_prevention",
 			"",
@@ -214,55 +243,20 @@ public enum ConfigNodes {
 			"# Example 1:  An entry with 'shield|diamond_sword' grants the feature to soldiers.",
 			"# Example 2:  An entry with 'compass|diamond_sword' grants the feature to scouts/explorers.",
 			"# Example 3:  An entry with 'compass|air' grants the feature to very peaceful explorers.",
-			"# Example 4:  An entry with 'compass|any' grants the feature to many players including builders/miners/lumberjacks."),
-	SPEED_ADJUSTMENTS(
-			"speed_adjustments",
+			"# Example 4:  An entry with 'compass|any' grants the feature to many players including builders/miners/lumberjacks."),	
+	ENCUMBRANCE(
+			"encumbrance",
 			"",
 			"",
 			"",
 			"############################################################",
 			"# +------------------------------------------------------+ #",
-			"# |                   SPEED ADJUSTMENTS                    | #",
+			"# |                     ENCUMBRANCE                      | #",
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
-	SPEED_ADJUSTMENTS_ENABLED(
-			"speed_adjustments.enabled",
-			"true",
-			"",
-			"# If this value is true, then speed adjustments are enabled:",
-			"# 1. The generic speed adjustments are usually set up too give a speed boost to all e.g. +12%.",
-			"# 2. Encumbrance, a standard concept across game genres, reduces player speed if they are carrying heavy stuff.",
-			"# ",
-			"# TIP 1: Encumbrance significantly boosts the tactical options available to armies.",
-			"# e.g instead of 'heavy infantry or ur loser', an army can seriously consider light infantry, light cavalry, heavy cavalry, archers, and skirmishers.",
-            "# ",
-			"# TIP 2: Encumbrance allows for the development of combat-useful uniforms.",
-			"# e.g. each nation may design national uniforms for different soldier types, including different materials, and (with leather items) colours."),
-	SPEED_ADJUSTMENTS_GENERIC(
-			"speed_adjustments.generic",
-			"",
-			"",
-			""),
-	SPEED_ADJUSTMENTS_GENERIC_INFANTRY_ADJUSTMENT_PERCENTAGE(
-			"speed_adjustments.generic.infantry_adjust_percent",
-			"12",
-			"",
-			"# Adjusts the walking speed of all players.",
-			"# TIP: Giving all players a small speed boost helps sugar-coat the concept of encumbrance."),
-	SPEED_ADJUSTMENTS_GENERIC_CAVALRY_ADJUSTMENT_PERCENTAGE(
-			"speed_adjustments.generic.cavalry_adjust_percent",
-			"12",
-			"",
-			"# Adjusts the walking speed of all player mounts.",
-			"# TIP: Giving all player mounts a small speed boost helps sugar-coat the concept of encumbrance."),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE(
-			"speed_adjustments.encumbrance",
-			"",
-			"",
-			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY(
-			"speed_adjustments.encumbrance.infantry",
+	ENCUMBRANCE_INFANTRY(
+			"encumbrance.infantry",
 			"",
 			"",
 			"",
@@ -270,110 +264,110 @@ public enum ConfigNodes {
 			"# |                      INFANTRY                        | #",
 			"# +------------------------------------------------------+ #",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE(
-			"speed_adjustments.encumbrance.infantry.base_percentage",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE(
+			"encumbrance.infantry.base_percentage",
 			"",
 			"",
 			"# The base slow percentage for each type of item."),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOW(
-			"speed_adjustments.encumbrance.infantry.base_percentage.bow",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOW(
+			"encumbrance.infantry.base_percentage.bow",
 			"3",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHIELD(
-			"speed_adjustments.encumbrance.infantry.base_percentage.shield",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHIELD(
+			"encumbrance.infantry.base_percentage.shield",
 			"4",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SPEAR(
-			"speed_adjustments.encumbrance.infantry.base_percentage.spear",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SPEAR(
+			"encumbrance.infantry.base_percentage.spear",
 			"5",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CROSSBOW(
-			"speed_adjustments.encumbrance.infantry.base_percentage.cross_bow",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CROSSBOW(
+			"encumbrance.encumbrance.infantry.base_percentage.cross_bow",
 			"12",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_WARHAMMER(
-			"speed_adjustments.encumbrance.infantry.base_percentage.warhammer",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_WARHAMMER(
+			"encumbrance.encumbrance.infantry.base_percentage.warhammer",
 			"12",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX(
-			"speed_adjustments.encumbrance.infantry.base_percentage.shulker_box",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX(
+			"encumbrance.encumbrance.infantry.base_percentage.shulker_box",
 			"15",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST(
-			"speed_adjustments.encumbrance.infantry.base_percentage.ender_chest",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST(
+			"encumbrance.encumbrance.infantry.base_percentage.ender_chest",
 			"30",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET(
-			"speed_adjustments.encumbrance.infantry.base_percentage.helmet",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET(
+			"encumbrance.encumbrance.infantry.base_percentage.helmet",
 			"0.6",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE(
-			"speed_adjustments.encumbrance.infantry.base_percentage.chestplate",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE(
+			"encumbrance.encumbrance.infantry.base_percentage.chestplate",
 			"1.6",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_LEGGINGS(
-			"speed_adjustments.encumbrance.infantry.base_percentage.leggings",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_LEGGINGS(
+			"encumbrance.encumbrance.infantry.base_percentage.leggings",
 			"1.2",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOOTS(
-			"speed_adjustments.encumbrance.infantry.base_percentage.boots",
+	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOOTS(
+			"encumbrance.encumbrance.infantry.base_percentage.boots",
 			"0.6",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE(
-			"speed_adjustments.encumbrance.infantry.modification_percentage",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE(
+			"encumbrance.encumbrance.infantry.modification_percentage",
 			"",
 			"",
 			"# The modification to encumbrance, of each material."),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_LEATHER(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.leather",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_LEATHER(
+			"encumbrance.encumbrance.infantry.modification_percentage.leather",
 			"100",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.chainmail",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL(
+			"encumbrance.encumbrance.infantry.modification_percentage.chainmail",
 			"200",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.turtle_shell",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL(
+			"encumbrance.encumbrance.infantry.modification_percentage.turtle_shell",
 			"300",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.gold",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD(
+			"encumbrance.encumbrance.infantry.modification_percentage.gold",
 			"300",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.iron",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON(
+			"encumbrance.encumbrance.infantry.modification_percentage.iron",
 			"400",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.diamond",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND(
+			"encumbrance.encumbrance.infantry.modification_percentage.diamond",
 			"500",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_NETHERITE(
-			"speed_adjustments.encumbrance.infantry.modification_percentage.netherite",
+	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_NETHERITE(
+			"encumbrance.encumbrance.infantry.modification_percentage.netherite",
 			"600",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE(
-			"speed_adjustments.encumbrance.infantry.jump_damage",
+	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE(
+			"encumbrance.encumbrance.infantry.jump_damage",
 			"",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_ENABLED(
-			"speed_adjustments.encumbrance.infantry.jump_damage.enabled",
+	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_ENABLED(
+			"encumbrance.encumbrance.infantry.jump_damage.enabled",
 			"true",
 			"",
 			"# If enabled, player with heavy armour sometimes take damage when they jump or ascend an incline.",
 			"# TIP: This setting stop players from exploiting/encumbrance-bypassing by 'bunny hopping' their way all over the battlefield."),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD(
-			"speed_adjustments.encumbrance.infantry.jump_damage.threshold",
+	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD(
+			"encumbrance.encumbrance.infantry.jump_damage.threshold",
 			"8",
 			"",
 			"# Players only take jump damage when their encumbrance is above this threshold.",
 			"# TIP: With default settings, jump damage will only apply to players carrying the equivalent of a full chain-mail set or heavier."),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT(
-			"speed_adjustments.encumbrance.infantry.jump_damage.damage_per_encumbrance_percent",
+	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT(
+			"encumbrance.encumbrance.infantry.jump_damage.damage_per_encumbrance_percent",
 			"0.07",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY(
-			"speed_adjustments.encumbrance.cavalry",
+	ENCUMBRANCE_CAVALRY(
+			"encumbrance.encumbrance.cavalry",
 			"",
 			"",
 			"",
@@ -381,30 +375,30 @@ public enum ConfigNodes {
 			"# |                      CAVALRY                         | #",
 			"# +------------------------------------------------------+ #",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_REDUCTION_PERCENTAGE(
-			"speed_adjustments.encumbrance.cavalry.reduction_percentage",
+	ENCUMBRANCE_CAVALRY_REDUCTION_PERCENTAGE(
+			"encumbrance.encumbrance.cavalry.reduction_percentage",
 			"50",
 			"",
 			"# Horses, being stronger, can carry more weight, thus their encumbrance is reduced"),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE(
-			"speed_adjustments.encumbrance.cavalry.percentage",
+	ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE(
+			"encumbrance.encumbrance.cavalry.percentage",
 			"",
 			"",
 			"# The slow percentage for each type of cavalry armour item."),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_LEATHER_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.percentage.leather_horse_armour",
+	ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_LEATHER_HORSE_ARMOUR(
+			"encumbrance.encumbrance.cavalry.percentage.leather_horse_armour",
 			"8",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_GOLD_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.percentage.gold_horse_armour",
+	ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_GOLD_HORSE_ARMOUR(
+			"encumbrance.encumbrance.cavalry.percentage.gold_horse_armour",
 			"24",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_IRON_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.percentage.iron_horse_armour",
+	ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_IRON_HORSE_ARMOUR(
+			"encumbrance.encumbrance.cavalry.percentage.iron_horse_armour",
 			"32",
 			""),
-	SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_DIAMOND_HORSE_ARMOUR(
-			"speed_adjustments.encumbrance.cavalry.percentage.diamond_horse_armour",
+	ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_DIAMOND_HORSE_ARMOUR(
+			"encumbrance.encumbrance.cavalry.percentage.diamond_horse_armour",
 			"40",
 			""),
 	NEW_ITEMS(

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -147,7 +147,7 @@ public class TownyCombatSettings {
 	}
 
 	public static boolean isTeleportMountWithPlayerEnabled() {
-		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_TELEPORT_MOUNT_WITH_PLAYER_ENABLED);
+		return Settings.getBoolean(ConfigNodes.CAVALRY_ENHANCEMENTS_TELEPORT_MOUNT_WITH_PLAYER_ENABLED);
 	}
 
 	public static boolean isBlockGlitchingPreventionEnabled() {
@@ -198,80 +198,76 @@ public class TownyCombatSettings {
 		return tacticalInvisibilityItems;
 	}
 
-	public static boolean isSpeedAdjustmentsEnabled() {
-		return Settings.getBoolean(ConfigNodes.SPEED_ADJUSTMENTS_ENABLED);
-	}
-
 	public static double getEquipmentEncumbranceBow() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOW);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOW);
 	}
 
 	public static double getEquipmentEncumbranceCrossbow() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CROSSBOW);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CROSSBOW);
 	}
 
 	public static double getEquipmentEncumbranceShield() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHIELD);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHIELD);
 	}
 
 	public static double getEquipmentEncumbranceBaseHelmet() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET);
 	}
 	
 	public static double getEquipmentEncumbranceBaseChestplate() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE);
 	}
 	
 	public static double getEquipmentEncumbranceBaseLeggings() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_LEGGINGS);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_LEGGINGS);
 	}
 	
 	public static double getEquipmentEncumbranceBaseBoots() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOOTS);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOOTS);
 	}
 	
 	public static double getEquipmentEncumbranceModificationLeather() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_LEATHER);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_LEATHER);
 	}
 	
 	public static double getEquipmentEncumbranceModificationChainmail() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL);
 	}
 
 	public static double getEquipmentEncumbranceModificationTurtleShell() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL);
 	}
 
 	public static double getEquipmentEncumbranceModificationGold() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD);
 	}		
 
 	public static double getEquipmentEncumbranceModificationIron() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON);
 	}
 	
 	public static double getEquipmentEncumbranceModificationDiamond() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND);
 	}		
 
 	public static double getEquipmentEncumbranceModificationNetherite() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_NETHERITE);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_NETHERITE);
 	}		
 	
 	public static double getEquipmentEncumbranceLeatherHorseArmour() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_LEATHER_HORSE_ARMOUR);		
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_LEATHER_HORSE_ARMOUR);		
 	}
 
 	public static double getEquipmentEncumbranceGoldHorseArmour() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_GOLD_HORSE_ARMOUR);		
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_GOLD_HORSE_ARMOUR);		
 	}
 
 	public static double getEquipmentEncumbranceIronHorseArmour() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_IRON_HORSE_ARMOUR);		
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_IRON_HORSE_ARMOUR);		
 	}
 
 	public static double getEquipmentEncumbranceDiamondHorseArmour() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_DIAMOND_HORSE_ARMOUR);		
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_CAVALRY_ITEM_PERCENTAGE_DIAMOND_HORSE_ARMOUR);		
 	}
 
 	public static Map<Material, Double> getMaterialEncumbrancePercentageMap() {
@@ -279,31 +275,35 @@ public class TownyCombatSettings {
 	}
 
 	public static double getGenericInfantrySpeedAdjustmentPercentage() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_GENERIC_INFANTRY_ADJUSTMENT_PERCENTAGE);
+		return Settings.getDouble(ConfigNodes.INFANTRY_ENHANCEMENTS_GENERIC_SPEED_ADJUSTMENT_PERCENT);
 	}
 	
 	public static double getGenericCavalrySpeedAdjustmentPercentage() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_GENERIC_CAVALRY_ADJUSTMENT_PERCENTAGE);
+		return Settings.getDouble(ConfigNodes.CAVALRY_ENHANCEMENTS_GENERIC_CAVALRY_ADJUSTMENT_PERCENTAGE);
 	}
 
-	public static double getDamageResistanceHorsesPercent() {
-		return Settings.getDouble(ConfigNodes.HORSE_ENHANCEMENTS_ATTACK_DAMAGE_RESISTANCE_PERCENT);
+	public static double getAttackDamageResistanceHorsesPercent() {
+		return Settings.getDouble(ConfigNodes.CAVALRY_ENHANCEMENTS_ATTACK_DAMAGE_RESISTANCE_PERCENT);
 	}
 
 	public static double getKnockbackResistanceHorsesPercent() {
-		return Settings.getInt(ConfigNodes.HORSE_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT);
+		return Settings.getInt(ConfigNodes.CAVALRY_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT);
+	}
+
+	public static double getKnockbackResistanceInfantryPercent() {
+		return Settings.getInt(ConfigNodes.INFANTRY_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT);
 	}
 
 	public static double getCavalryEncumbranceReductionPercentage() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_REDUCTION_PERCENTAGE);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_CAVALRY_REDUCTION_PERCENTAGE);
 	}
 
 	public static double getEquipmentEncumbranceSpear() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SPEAR);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SPEAR);
 	}
 
 	public static double getEquipmentEncumbranceWarhammer() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_WARHAMMER);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_WARHAMMER);
 	}
 
 	public static boolean isNewItemsSpearEnabled() {
@@ -347,11 +347,11 @@ public class TownyCombatSettings {
 	}
 
 	public static double getEquipmentEncumbranceShulkerBox() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX);
 	}
 
 	public static double getEquipmentEncumbranceEnderChest() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST);
 	}
 
 	public static boolean isAutoPottingEnabled() {
@@ -363,23 +363,23 @@ public class TownyCombatSettings {
 	}
 
 	public static boolean isCavalryFireShieldEnabled() {
-		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_FIRE_SHIELD_ENABLED);
+		return Settings.getBoolean(ConfigNodes.CAVALRY_ENHANCEMENTS_CAVALRY_FIRE_SHIELD_ENABLED);
 	}
 	
 	public static boolean isCavalryMissileShieldEnabled() {
-		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_MISSILE_SHIELD_ENABLED);
+		return Settings.getBoolean(ConfigNodes.CAVALRY_ENHANCEMENTS_CAVALRY_MISSILE_SHIELD_ENABLED);
 	}
 	
 	public static boolean isCavalryStrengthBonusEnabled() {
-		return Settings.getBoolean(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_ENABLED);
+		return Settings.getBoolean(ConfigNodes.CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_ENABLED);
 	}
 
 	public static int getCavalryChargeStrengthBonusEffectLevel() {
-		return Settings.getInt(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_EFFECT_LEVEL);
+		return Settings.getInt(ConfigNodes.CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_EFFECT_LEVEL);
 	}
 
 	public static double getCavalryStrengthBonusCooldownSeconds() {
-		return Settings.getDouble(ConfigNodes.HORSE_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_COOLDOWN_SECONDS);
+		return Settings.getDouble(ConfigNodes.CAVALRY_ENHANCEMENTS_CAVALRY_STRENGTH_BONUS_COOLDOWN_SECONDS);
 	}
 
 	public static int getCavalryChargeCooldownMilliseconds() {
@@ -391,18 +391,14 @@ public class TownyCombatSettings {
 	}
 	
 	public static boolean isJumpDamageEnabled() {
-		return Settings.getBoolean(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_ENABLED);
+		return Settings.getBoolean(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_ENABLED);
 	}
 	
 	public static double getJumpDamageThreshold() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD);
 	}
 
 	public static double getJumpDamageDamagePerEncumbrancePercent() {
-		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT);
-	}
-
-	public static String translateColoursInString(final String string) {
-	  	return ChatColor.translateAlternateColorCodes('&', string);
+		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT);
 	}
 }

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -290,6 +290,10 @@ public class TownyCombatSettings {
 		return Settings.getDouble(ConfigNodes.HORSE_ENHANCEMENTS_ATTACK_DAMAGE_RESISTANCE_PERCENT);
 	}
 
+	public static double getKnockbackResistanceHorsesPercent() {
+		return Settings.getInt(ConfigNodes.HORSE_ENHANCEMENTS_KNOCKBACK_RESISTANCE_PERCENT);
+	}
+
 	public static double getCavalryEncumbranceReductionPercentage() {
 		return Settings.getDouble(ConfigNodes.SPEED_ADJUSTMENTS_ENCUMBRANCE_CAVALRY_REDUCTION_PERCENTAGE);
 	}

--- a/src/main/java/io/github/townyadvanced/townycombat/tasks/TownyCombatTask.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/tasks/TownyCombatTask.java
@@ -30,7 +30,7 @@ public class TownyCombatTask extends BukkitRunnable {
         if (!TownyCombatSettings.isTownyCombatEnabled())
 			return;
         //Execute the jump restriction every 0.5 seconds.
-        if(TownyCombatSettings.isSpeedAdjustmentsEnabled() && TownyCombatSettings.isJumpDamageEnabled()) {
+        if(TownyCombatSettings.isJumpDamageEnabled()) {
             TownyCombatMovementUtil.punishEncumberedJumpingPlayers();
         }
         //Execute the cavalry charge refreshes every 1 second.

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatItemUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatItemUtil.java
@@ -3,6 +3,7 @@ package io.github.townyadvanced.townycombat.utils;
 import io.github.townyadvanced.townycombat.settings.TownyCombatSettings;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
@@ -209,18 +210,15 @@ public class TownyCombatItemUtil {
                 PotionData potionData = ((PotionMeta) itemStack.getItemMeta()).getBasePotionData();
                 if(potionData.getType() != PotionType.INSTANT_HEAL)
                     continue;
-                //Use potion
-                if(potionData.isUpgraded()) {
-                    primaryRecipient.setHealth(primaryRecipient.getHealth() + 10);
-                    if(secondaryRecipient != null) {
-                        secondaryRecipient.setHealth(secondaryRecipient.getHealth() + 10);
-                    }
-                } else {
-                    primaryRecipient.setHealth(primaryRecipient.getHealth() + 5);
-                    if(secondaryRecipient != null) {
-                        secondaryRecipient.setHealth(secondaryRecipient.getHealth() + 5);
-                    }
-                }
+                double healAmount = potionData.isUpgraded() ? 10: 5;
+
+                //Heal Primary
+                healLivingEntity(primaryRecipient, healAmount);
+
+                //Heal Secondary
+                if(secondaryRecipient != null)
+                    healLivingEntity(secondaryRecipient, healAmount);
+
                 //Remove potion
                 itemStack.setAmount(0);
                 //Return if the primary recipient is healed enough
@@ -229,6 +227,12 @@ public class TownyCombatItemUtil {
                 }
             }
         }
+    }
+
+    private static void healLivingEntity(LivingEntity recipient, double healAmount) {
+        double newHealth = recipient.getHealth() + healAmount;
+        final double finalHealth = Math.max(0, Math.min(recipient.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(), newHealth)); //apply min and max
+        recipient.setHealth(finalHealth);
     }
 
     /**

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -45,6 +45,8 @@ public class TownyCombatMovementUtil {
         adjustPlayerWalkSpeed(player);
         //Apply adjustments to mount walk speed
         adjustMountWalkSpeed(player);
+        //Apply adjustments to mount knockback resistance
+        adjustMountKnockbackResistance(player);
     }
 
     public static void removeTownyCombatMovementAttributeModifiers(LivingEntity livingEntity) {
@@ -133,6 +135,26 @@ public class TownyCombatMovementUtil {
         mount.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).addModifier(attributeModifier);
     }
     
+    public static void adjustMountKnockbackResistance(Player player) {
+        if(!player.isInsideVehicle() || !(player.getVehicle() instanceof AbstractHorse))
+            return;
+        AbstractHorse mount = (AbstractHorse)player.getVehicle();
+        double scalarAdjustment =TownyCombatSettings.getKnockbackResistanceHorsesPercent() / 100;
+        if(scalarAdjustment == 0)
+            return;
+
+        //Remove old modifier
+        for(AttributeModifier attributeModifier: new ArrayList<>(mount.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getModifiers())) {
+            if(attributeModifier.getName().equals(ATTRIBUTE_MODIFIER_NAME)) {
+                mount.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).removeModifier(attributeModifier);
+            }
+        }
+
+        //Add new modifier
+        AttributeModifier attributeModifier = new AttributeModifier(ATTRIBUTE_MODIFIER_NAME, scalarAdjustment, AttributeModifier.Operation.ADD_NUMBER);
+        mount.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).addModifier(attributeModifier);
+    }
+
     public static Map<Player, Double> getPlayerEncumbrancePercentageMap() {
         return playerEncumbrancePercentageMap;
     }

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatMovementUtil.java
@@ -45,16 +45,23 @@ public class TownyCombatMovementUtil {
         adjustPlayerWalkSpeed(player);
         //Apply adjustments to mount walk speed
         adjustMountWalkSpeed(player);
+        //Apply adjustments to player knockback resistance
+        adjustPlayerKnockbackResistance(player);
         //Apply adjustments to mount knockback resistance
         adjustMountKnockbackResistance(player);
     }
 
-    public static void removeTownyCombatMovementAttributeModifiers(LivingEntity livingEntity) {
+    public static void removeTownyCombatMovementModifiers(LivingEntity livingEntity) {
         //Remove the TCM modifiers
         for(AttributeModifier attributeModifier: new ArrayList<>(livingEntity.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getModifiers())) {
             if(attributeModifier.getName().equals(ATTRIBUTE_MODIFIER_NAME)) {
                 livingEntity.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).removeModifier(attributeModifier);
             }                
+        }
+        for(AttributeModifier attributeModifier: new ArrayList<>(livingEntity.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).getModifiers())) {
+            if(attributeModifier.getName().equals(ATTRIBUTE_MODIFIER_NAME)) {
+                livingEntity.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).removeModifier(attributeModifier);
+            }
         }
     }
 
@@ -134,7 +141,24 @@ public class TownyCombatMovementUtil {
         AttributeModifier attributeModifier = new AttributeModifier(ATTRIBUTE_MODIFIER_NAME, scalarAdjustment, AttributeModifier.Operation.ADD_SCALAR);
         mount.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).addModifier(attributeModifier);
     }
-    
+
+    public static void adjustPlayerKnockbackResistance(Player player) {
+        double scalarAdjustment =TownyCombatSettings.getKnockbackResistanceInfantryPercent() / 100;
+        if(scalarAdjustment == 0)
+            return;
+
+        //Remove old modifier
+        for(AttributeModifier attributeModifier: new ArrayList<>(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getModifiers())) {
+            if(attributeModifier.getName().equals(ATTRIBUTE_MODIFIER_NAME)) {
+                player.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).removeModifier(attributeModifier);
+            }
+        }
+
+        //Add new modifier
+        AttributeModifier attributeModifier = new AttributeModifier(ATTRIBUTE_MODIFIER_NAME, scalarAdjustment, AttributeModifier.Operation.ADD_NUMBER);
+        player.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).addModifier(attributeModifier);
+    }
+
     public static void adjustMountKnockbackResistance(Player player) {
         if(!player.isInsideVehicle() || !(player.getVehicle() instanceof AbstractHorse))
             return;


### PR DESCRIPTION
#### Description
- Added knockback resistance for horses
- Also added it for players
- Also fixed a bug with autopotting
- Also cleaned up the naming scheme in some of the configs

#### Config Nodes
```
  # This setting makes mounted-horses resistant to knockback.
  # TIP: This setting helps cavalry to avoid getting knocked into holes/ganks etc.
  knockback_resistance_percent: '75'
...
  # This setting makes players resistant to knockback.
  # TIP: This setting helps players to avoid getting knocked into holes/ganks etc.
  knockback_resistance_percent: '25'    
```
____
#### Relevant Issue ticket:
Closes #48 

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyCombat [License](https://github.com/TownyAdvanced/TownyCombat/blob/master/LICENSE.md) for perpetuity.


