### PR TITLE
Added jump damage warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyCombat</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
   <name>townycombat</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -281,89 +281,94 @@ public enum ConfigNodes {
 			"5",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CROSSBOW(
-			"encumbrance.encumbrance.infantry.base_percentage.cross_bow",
+			"encumbrance.infantry.base_percentage.cross_bow",
 			"12",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_WARHAMMER(
-			"encumbrance.encumbrance.infantry.base_percentage.warhammer",
+			"encumbrance.infantry.base_percentage.warhammer",
 			"12",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_SHULKER_BOX(
-			"encumbrance.encumbrance.infantry.base_percentage.shulker_box",
+			"encumbrance.infantry.base_percentage.shulker_box",
 			"15",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_ENDER_CHEST(
-			"encumbrance.encumbrance.infantry.base_percentage.ender_chest",
+			"encumbrance.infantry.base_percentage.ender_chest",
 			"30",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_HELMET(
-			"encumbrance.encumbrance.infantry.base_percentage.helmet",
+			"encumbrance.infantry.base_percentage.helmet",
 			"0.6",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_CHESTPLATE(
-			"encumbrance.encumbrance.infantry.base_percentage.chestplate",
+			"encumbrance.infantry.base_percentage.chestplate",
 			"1.6",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_LEGGINGS(
-			"encumbrance.encumbrance.infantry.base_percentage.leggings",
+			"encumbrance.infantry.base_percentage.leggings",
 			"1.2",
 			""),
 	ENCUMBRANCE_INFANTRY_BASE_ITEM_PERCENTAGE_BOOTS(
-			"encumbrance.encumbrance.infantry.base_percentage.boots",
+			"encumbrance.infantry.base_percentage.boots",
 			"0.6",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE(
-			"encumbrance.encumbrance.infantry.modification_percentage",
+			"encumbrance.infantry.modification_percentage",
 			"",
 			"",
 			"# The modification to encumbrance, of each material."),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_LEATHER(
-			"encumbrance.encumbrance.infantry.modification_percentage.leather",
+			"encumbrance.infantry.modification_percentage.leather",
 			"100",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_CHAINMAIL(
-			"encumbrance.encumbrance.infantry.modification_percentage.chainmail",
+			"encumbrance.infantry.modification_percentage.chainmail",
 			"200",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_TURTLE_SHELL(
-			"encumbrance.encumbrance.infantry.modification_percentage.turtle_shell",
+			"encumbrance.infantry.modification_percentage.turtle_shell",
 			"300",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_GOLD(
-			"encumbrance.encumbrance.infantry.modification_percentage.gold",
+			"encumbrance.infantry.modification_percentage.gold",
 			"300",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_IRON(
-			"encumbrance.encumbrance.infantry.modification_percentage.iron",
+			"encumbrance.infantry.modification_percentage.iron",
 			"400",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_DIAMOND(
-			"encumbrance.encumbrance.infantry.modification_percentage.diamond",
+			"encumbrance.infantry.modification_percentage.diamond",
 			"500",
 			""),
 	ENCUMBRANCE_INFANTRY_MATERIAL_MODIFICATION_PERCENTAGE_NETHERITE(
-			"encumbrance.encumbrance.infantry.modification_percentage.netherite",
+			"encumbrance.infantry.modification_percentage.netherite",
 			"600",
 			""),
 	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE(
-			"encumbrance.encumbrance.infantry.jump_damage",
+			"encumbrance.infantry.jump_damage",
 			"",
 			""),
 	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_ENABLED(
-			"encumbrance.encumbrance.infantry.jump_damage.enabled",
+			"encumbrance.infantry.jump_damage.enabled",
 			"true",
 			"",
 			"# If enabled, player with heavy armour sometimes take damage when they jump or ascend an incline.",
 			"# TIP: This setting stop players from exploiting/encumbrance-bypassing by 'bunny hopping' their way all over the battlefield."),
 	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD(
-			"encumbrance.encumbrance.infantry.jump_damage.threshold",
+			"encumbrance.infantry.jump_damage.threshold",
 			"8",
 			"",
+			"# Integer only",
 			"# Players only take jump damage when their encumbrance is above this threshold.",
 			"# TIP: With default settings, jump damage will only apply to players carrying the equivalent of a full chain-mail set or heavier."),
 	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT(
-			"encumbrance.encumbrance.infantry.jump_damage.damage_per_encumbrance_percent",
+			"encumbrance.infantry.jump_damage.damage_per_encumbrance_percent",
 			"0.07",
+			""),
+	ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_WARNING_INTERVAL_MINUTES(
+			"encumbrance.infantry.jump_damage.warning_interval_minutes",
+			"60",
 			""),
 	ENCUMBRANCE_CAVALRY(
 			"encumbrance.encumbrance.cavalry",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -393,11 +393,15 @@ public class TownyCombatSettings {
 		return Settings.getBoolean(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_ENABLED);
 	}
 	
-	public static double getJumpDamageThreshold() {
-		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD);
+	public static int getJumpDamageThreshold() {
+		return Settings.getInt(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_THRESHOLD);
 	}
 
 	public static double getJumpDamageDamagePerEncumbrancePercent() {
 		return Settings.getDouble(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_DAMAGE_PER_ENCUMBRANCE_PERCENT);
+	}
+
+	public static int getJumpDamageWarningIntervalMinutes() {
+		return Settings.getInt(ConfigNodes.ENCUMBRANCE_INFANTRY_JUMP_DAMAGE_WARNING_INTERVAL_MINUTES);
 	}
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: TownyCombat
-version: 0.01
+version: 0.02
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -30,3 +30,6 @@ msg_inventory_degrade_warning: '&4WARNING: &cSome of your gear is close to break
 admin_help_reload: 'Reload the config and language file.'
 config_and_lang_file_reloaded_successfully: 'Config and Language file reloaded successfully.'
 config_and_lang_file_could_not_be_reloaded: 'Reload unsuccessful. See console for details.'
+
+# Added in 0.02
+msg_warning_jump_damage: '&cWARNING: Your encumbrance level is above %d percent. Be careful when jumping or climbing a hill, as this will cause tiredness-damage.'


### PR DESCRIPTION
#### Description
- With current code the jumping-while-encumbered damage can surprise players by um killing them :-D
- This PR adds a warning

#### Config Nodes
```
  encumbrance:
    jump_damage:
      warning_interval_minutes: '60'
```
____
#### Relevant Issue ticket:
N/A

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the TownyCombat [License](https://github.com/TownyAdvanced/TownyCombat/blob/master/LICENSE.md) for perpetuity.


