### PR TITLE
Remove encumberance on death.

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -83,8 +83,10 @@ public class TownyCombatBukkitEventListener implements Listener {
 			event.setCancelled(true);
 			event.getEntity().getUniqueId();
 		}
+
 		//Apply speed adjustments
-		TownyCombatMovementUtil.adjustPlayerAndMountSpeeds((Player)event.getEntity());
+		if (TownyCombatSettings.isMovementModificationEnabled())
+			TownyCombatMovementUtil.adjustPlayerAndMountSpeeds((Player)event.getEntity());
 		//Register for charge bonus
 		TownyCombatHorseUtil.registerPlayerForCavalryStrengthBonus((Player)event.getEntity());
 	}
@@ -110,10 +112,14 @@ public class TownyCombatBukkitEventListener implements Listener {
 		if(TownyCombatSettings.isKeepInventoryOnDeathEnabled()) {
 			TownyCombatInventoryUtil.degradeInventory(event);
 			TownyCombatInventoryUtil.keepInventory(event);
+		} else if (TownyCombatSettings.isMovementModificationEnabled()) {
+			// Remove any movement penalties if inventory is not kept.
+			TownyCombatMovementUtil.removeTownyCombatMovementModifiers(event.getEntity());
 		}
 		if(TownyCombatSettings.isKeepExperienceOnDeathEnabled()) {
 			TownyCombatExperienceUtil.keepExperience(event);
 		}
+
 	}
 
 	@EventHandler (ignoreCancelled = true)
@@ -121,7 +127,7 @@ public class TownyCombatBukkitEventListener implements Listener {
 		//Remove legacy data
 		TownyCombatMovementUtil.resetPlayerBaseSpeedToVanilla(event.getPlayer());
 		//Remove modifiers if system/feature is disabled
-		if (!TownyCombatSettings.isTownyCombatEnabled()) {
+		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isMovementModificationEnabled()) {
 			TownyCombatMovementUtil.removeTownyCombatMovementModifiers(event.getPlayer());
 		} else {
 			TownyCombatMovementUtil.adjustPlayerAndMountSpeeds(event.getPlayer());

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatTownyEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatTownyEventListener.java
@@ -1,6 +1,5 @@
 package io.github.townyadvanced.townycombat.listeners;
 
-import com.palmergames.bukkit.towny.event.NewDayEvent;
 import com.palmergames.bukkit.towny.event.actions.TownyBuildEvent;
 import com.palmergames.bukkit.towny.event.actions.TownyDestroyEvent;
 import com.palmergames.bukkit.towny.event.time.NewShortTimeEvent;
@@ -48,7 +47,8 @@ public class TownyCombatTownyEventListener implements Listener {
     public void onShortTime(NewShortTimeEvent event) {
         if (!TownyCombatSettings.isTownyCombatEnabled())
         	return;
-		TownyCombatMovementUtil.adjustAllPlayerAndMountSpeeds();
+        if (TownyCombatSettings.isMovementModificationEnabled())
+        	TownyCombatMovementUtil.adjustAllPlayerAndMountSpeeds();
 		if(TownyCombatSettings.isTacticalInvisibilityEnabled()) {
 			TownyCombatMapUtil.evaluateTacticalInvisibility();
 			TownyCombatMapUtil.applyTacticalInvisibilityToPlayers();

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/ConfigNodes.java
@@ -18,7 +18,13 @@ public enum ConfigNodes {
 			"towny_combat_enabled",
 			"true",
 			"",
-			"# etc."),
+			"# Enables the entire plugin."),
+	TOWNY_COMBAT_MOVEMENT_MODIFICATIONS_ENABLED(
+			"movement_modifications_enabled",
+			"true",
+			"",
+			"# Enables the entire movements-modifications system."),
+
 	CAVALRY_ENHANCEMENTS(
 		"cavalry_enhancements",
 			"",

--- a/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/settings/TownyCombatSettings.java
@@ -145,6 +145,10 @@ public class TownyCombatSettings {
 		return Settings.getBoolean(ConfigNodes.TOWNY_COMBAT_ENABLED);
 	}
 
+	public static boolean isMovementModificationEnabled() {
+		return Settings.getBoolean(ConfigNodes.TOWNY_COMBAT_MOVEMENT_MODIFICATIONS_ENABLED);
+	}
+
 	public static boolean isTeleportMountWithPlayerEnabled() {
 		return Settings.getBoolean(ConfigNodes.CAVALRY_ENHANCEMENTS_TELEPORT_MOUNT_WITH_PLAYER_ENABLED);
 	}


### PR DESCRIPTION
  - Part of #64.

Bonus config option to disable the movement related things.

New Config Option: movement_modifications_enabled
  - Default: true
  - Enables the entire movements-modifications system.