### PR TITLE
Features and fixes for Battlefield Roles

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -1,9 +1,7 @@
 package io.github.townyadvanced.townycombat.listeners;
 
-import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Translatable;
 import io.github.townyadvanced.townycombat.TownyCombat;
-import io.github.townyadvanced.townycombat.events.BattlefieldRole;
 import io.github.townyadvanced.townycombat.events.TownyCombatSpecialCavalryHitEvent;
 import io.github.townyadvanced.townycombat.settings.TownyCombatSettings;
 import io.github.townyadvanced.townycombat.utils.Messaging;

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -1,8 +1,12 @@
 package io.github.townyadvanced.townycombat.listeners;
 
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Translatable;
 import io.github.townyadvanced.townycombat.TownyCombat;
+import io.github.townyadvanced.townycombat.events.BattlefieldRole;
 import io.github.townyadvanced.townycombat.events.TownyCombatSpecialCavalryHitEvent;
 import io.github.townyadvanced.townycombat.settings.TownyCombatSettings;
+import io.github.townyadvanced.townycombat.utils.Messaging;
 import io.github.townyadvanced.townycombat.utils.TownyCombatBattlefieldRoleUtil;
 import io.github.townyadvanced.townycombat.utils.TownyCombatHorseUtil;
 import io.github.townyadvanced.townycombat.utils.TownyCombatMovementUtil;
@@ -22,6 +26,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
@@ -31,7 +36,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.spigotmc.event.entity.EntityDismountEvent;
 import org.spigotmc.event.entity.EntityMountEvent;
@@ -159,11 +163,43 @@ public class TownyCombatBukkitEventListener implements Listener {
 		return cause.equals(DamageCause.CONTACT) || cause.equals(DamageCause.FIRE);
 	}
 
+	@EventHandler
+	public void on (EntityShootBowEvent event) {
+		if (!TownyCombatSettings.isTownyCombatEnabled())
+			return;
+
+		if(TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() && TownyCombatSettings.isBattlefieldRolesEnabled()) {
+			if(event.getBow() == null)
+				return;
+			if(!(event.getEntity() instanceof Player)) 
+				return;
+			if(!TownyCombatBattlefieldRoleUtil.isItemAllowedByBattlefieldRole(event.getBow(), (Player)event.getEntity())) {
+				event.setCancelled(true);
+				Messaging.sendMsg(event.getEntity(), Translatable.of("msg_warning_cannot_wield_this_weapon").append("msg_warning_how_to_view_and_change_role"));
+			}
+		}
+	}
+	
 	@EventHandler (ignoreCancelled = true)
 	public void on (EntityDamageByEntityEvent event) {
 		if (!TownyCombatSettings.isTownyCombatEnabled())
 			return;
 
+		if(TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() && TownyCombatSettings.isBattlefieldRolesEnabled()) {
+			if(event.getDamager() instanceof Player && event.getEntity() instanceof Player) {
+				/*
+				 * PVP event Detected
+				 * Cancel if the damager is holding a disallowed weapon
+				 */
+				if(!TownyCombatBattlefieldRoleUtil.isItemAllowedByBattlefieldRole(
+						((Player)event.getDamager()).getInventory().getItemInMainHand(), 
+						(Player)event.getDamager())) {
+					event.setCancelled(true);
+					Messaging.sendMsg(event.getDamager(), Translatable.of("msg_warning_cannot_wield_this_weapon").append("msg_warning_how_to_view_and_change_role"));
+				}
+			}
+		}
+		
 		//Get attacking player (if any)	
 		Player attackingPlayer;
 		if(event.getDamager() instanceof Player) {
@@ -321,7 +357,7 @@ public class TownyCombatBukkitEventListener implements Listener {
 	public void on (InventoryCloseEvent event) {
 		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() || !TownyCombatSettings.isBattlefieldRolesEnabled())
 			return;
-		TownyCombatBattlefieldRoleUtil.validateInventoryContents(event.getPlayer());
+		TownyCombatBattlefieldRoleUtil.validateArmourSlots(event.getPlayer());
 	}
 
 	@EventHandler

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -26,10 +26,12 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.spigotmc.event.entity.EntityDismountEvent;
 import org.spigotmc.event.entity.EntityMountEvent;
@@ -321,4 +323,17 @@ public class TownyCombatBukkitEventListener implements Listener {
 			return;
 		TownyCombatBattlefieldRoleUtil.validateInventoryContents(event.getPlayer());
 	}
+
+	@EventHandler
+	public void on (PlayerItemConsumeEvent event) {
+		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() || !TownyCombatSettings.isBattlefieldRolesEnabled())
+			return;
+		if (event.getItem().getType() == Material.POTION) {
+			ItemStack updatedPotion = TownyCombatBattlefieldRoleUtil.getAmplifiedPotion(event.getPlayer(), event.getItem());
+			if (updatedPotion != null) {
+				event.setItem(updatedPotion);
+			}
+		}
+	}
+
 }

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatStatusScreenListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatStatusScreenListener.java
@@ -30,6 +30,7 @@ public class TownyCombatStatusScreenListener implements Listener {
 	public void onResidentStatusScreen(ResidentStatusScreenEvent event) {
 		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() || !TownyCombatSettings.isBattlefieldRolesEnabled())
 			return;
+
 		//Create the hover item subcomponents
 		BattlefieldRole battlefieldRole = TownyCombatBattlefieldRoleUtil.getBattlefieldRole(event.getResident());
 		final Translator translator = Translator.locale(event.getCommandSender());

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatStatusScreenListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatStatusScreenListener.java
@@ -30,7 +30,6 @@ public class TownyCombatStatusScreenListener implements Listener {
 	public void onResidentStatusScreen(ResidentStatusScreenEvent event) {
 		if (!TownyCombatSettings.isTownyCombatEnabled() || !TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() || !TownyCombatSettings.isBattlefieldRolesEnabled())
 			return;
-
 		//Create the hover item subcomponents
 		BattlefieldRole battlefieldRole = TownyCombatBattlefieldRoleUtil.getBattlefieldRole(event.getResident());
 		final Translator translator = Translator.locale(event.getCommandSender());

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatBattlefieldRoleUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatBattlefieldRoleUtil.java
@@ -13,52 +13,81 @@ import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class TownyCombatBattlefieldRoleUtil {
 
-    public static final List<Material> lightRoleArmour = Arrays.asList(Material.LEATHER_BOOTS, Material.LEATHER_CHESTPLATE, Material.LEATHER_HELMET, Material.LEATHER_LEGGINGS);
-    public static final List<Material> lightRoleWeapons = Arrays.asList(Material.BOW, Material.WOODEN_SWORD, Material.WOODEN_AXE);
-    public static final Map<Material, List<BattlefieldRole>> armourBattlefieldRoleMap;
-    public static final Map<Material, List<BattlefieldRole>> weaponBattlefieldRoleMap;
+    public static final List<Material> leatherArmour = Arrays.asList(Material.LEATHER_BOOTS, Material.LEATHER_CHESTPLATE, Material.LEATHER_HELMET, Material.LEATHER_LEGGINGS);
+    public static final List<Material> ironArmour = Arrays.asList(Material.IRON_BOOTS, Material.IRON_CHESTPLATE, Material.IRON_HELMET, Material.IRON_LEGGINGS);
+    public static final List<Material> chainArmour = Arrays.asList(Material.CHAINMAIL_BOOTS, Material.CHAINMAIL_CHESTPLATE, Material.CHAINMAIL_HELMET, Material.CHAINMAIL_LEGGINGS);
+    public static final List<Material> turtleArmour = Arrays.asList(Material.TURTLE_HELMET);
+    public static final List<Material> goldArmour = Arrays.asList(Material.GOLDEN_BOOTS, Material.GOLDEN_CHESTPLATE, Material.GOLDEN_HELMET, Material.GOLDEN_LEGGINGS);
+    public static final List<Material> diamondArmour = Arrays.asList(Material.DIAMOND_BOOTS, Material.DIAMOND_CHESTPLATE, Material.DIAMOND_HELMET, Material.DIAMOND_LEGGINGS);
+    public static final List<Material> netheriteArmour = Arrays.asList(Material.NETHERITE_BOOTS, Material.NETHERITE_CHESTPLATE, Material.NETHERITE_HELMET, Material.NETHERITE_LEGGINGS);
+    public static final List<Material> woodenWeapons = Arrays.asList(Material.WOODEN_SWORD, Material.WOODEN_AXE);
+    public static final List<Material> stoneWeapons = Arrays.asList(Material.STONE_SWORD, Material.STONE_AXE);
+    public static final List<Material> ironWeapons = Arrays.asList(Material.IRON_SWORD, Material.IRON_AXE);
+    public static final List<Material> diamondWeapons = Arrays.asList(Material.DIAMOND_SWORD, Material.DIAMOND_AXE);
+    public static final List<Material> netheriteWeapons = Arrays.asList(Material.NETHERITE_SWORD, Material.NETHERITE_AXE);
+    public static final Map<Material, Set<BattlefieldRole>> armourBattlefieldRoleMap;
+    public static final Map<Material, Set<BattlefieldRole>> weaponBattlefieldRoleMap;
 
     static {
         armourBattlefieldRoleMap = new HashMap<>();
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, leatherArmour, BattlefieldRole.LIGHT);
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, ironArmour, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, chainArmour, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, turtleArmour, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, goldArmour, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, diamondArmour, BattlefieldRole.HEAVY);
+        addMaterialsToBattlefieldRoleMap(armourBattlefieldRoleMap, netheriteArmour, BattlefieldRole.HEAVY);
+        
         weaponBattlefieldRoleMap = new HashMap<>();
-        addToMaterialBattlefieldRoleMap(armourBattlefieldRoleMap, lightRoleArmour, BattlefieldRole.LIGHT);
-        addToMaterialBattlefieldRoleMap(weaponBattlefieldRoleMap, lightRoleWeapons, BattlefieldRole.LIGHT);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, woodenWeapons, BattlefieldRole.LIGHT);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, stoneWeapons, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, ironWeapons, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, diamondWeapons, BattlefieldRole.HEAVY);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, netheriteWeapons, BattlefieldRole.HEAVY);
     }
-    
-    private static void addToMaterialBattlefieldRoleMap(Map<Material, List<BattlefieldRole>> materialBattlefieldRoleMap, List<Material> materialList, BattlefieldRole battlefieldRole) {
+
+    private static void addMaterialsToBattlefieldRoleMap(Map<Material, Set<BattlefieldRole>> materialBattlefieldRoleMap, List<Material> materialList, BattlefieldRole battlefieldRole) {
         for(Material material: materialList) {
             if(materialBattlefieldRoleMap.containsKey(material)) {
                 materialBattlefieldRoleMap.get(material).add(battlefieldRole);
             } else {
-                List<BattlefieldRole> battlefieldRoleList = new ArrayList<>();
-                battlefieldRoleList.add(battlefieldRole);
-                materialBattlefieldRoleMap.put(material, battlefieldRoleList);
+                Set<BattlefieldRole> battlefieldRoleSet = new HashSet<>();
+                battlefieldRoleSet.add(battlefieldRole);
+                materialBattlefieldRoleMap.put(material, battlefieldRoleSet);
             }
         }
     }
+
+    public static boolean isItemAllowedByBattlefieldRole(ItemStack itemStack, Player player) {
+        Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
+        if (resident == null)
+            return true;  //Edge case
+        BattlefieldRole playerBattlefieldRole = getBattlefieldRole(resident);
+        return isMaterialAllowedByBattlefieldRole(weaponBattlefieldRoleMap, itemStack.getType(), playerBattlefieldRole);
+    }
     
-    public static boolean isMaterialAllowedByBattlefieldRole(Map<Material, List<BattlefieldRole>> materialRoleMap, Material material, BattlefieldRole battlefieldRole) {
-        List<BattlefieldRole> rolesWhichCanUseThisItem = materialRoleMap.get(material);
+    private static boolean isMaterialAllowedByBattlefieldRole(Map<Material, Set<BattlefieldRole>> materialRoleMap, Material material, BattlefieldRole battlefieldRole) {
+        Set<BattlefieldRole> rolesWhichCanUseThisItem = materialRoleMap.get(material);
         if(rolesWhichCanUseThisItem == null) {
-            return true; //Anyone can use it
+            return true; //No restrictions on this material
         } else {
             return rolesWhichCanUseThisItem.contains(battlefieldRole);
         }
@@ -69,35 +98,24 @@ public class TownyCombatBattlefieldRoleUtil {
         return BattlefieldRole.parseString(roleAsString);
     }
 
-    public static void validateInventoryContents(HumanEntity player) {
+    public static void validateArmourSlots(HumanEntity player) {
         Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
         if (resident == null)
             return;
         //Create Convenience variables
         BattlefieldRole playerBattlefieldRole = getBattlefieldRole(resident);
         ItemStack[] inventoryContents = player.getInventory().getContents();
-        List<Integer> invalidArmourIndexes = new ArrayList<>();
-        List<Integer> invalidWeaponIndexes = new ArrayList<>();
+        List<Integer> invalidInventoryIndexes = new ArrayList<>();
         //Identify invalid armour (Slots 36-39)
         for(int i = 36; i <= 39; i++) {
             ItemStack itemStack = inventoryContents[i];
             if(itemStack != null && isMaterialAllowedByBattlefieldRole(armourBattlefieldRoleMap, itemStack.getType(), playerBattlefieldRole)) {
-                invalidArmourIndexes.add(i);
+                invalidInventoryIndexes.add(i);
             }
         }
-        //Identify Invalid Weapons (Slots 0-8 is hotbar)
-        for(int i = 0; i <= 8; i++) {
-            ItemStack itemStack = inventoryContents[i];
-            if(itemStack != null && isMaterialAllowedByBattlefieldRole(armourBattlefieldRoleMap, itemStack.getType(), playerBattlefieldRole)) {
-                invalidWeaponIndexes.add(i);
-            }
-        }
-        //Drop all Invalid Items           
-        List<Integer> invalidItemIndexes = new ArrayList<>();
-        invalidItemIndexes.addAll(invalidArmourIndexes);
-        invalidItemIndexes.addAll(invalidWeaponIndexes);
+        //Drop Invalid armour           
         Towny.getPlugin().getServer().getScheduler().runTask(Towny.getPlugin(), () -> {
-            for(Integer inventoryIndex: invalidItemIndexes) {
+            for(int inventoryIndex: invalidInventoryIndexes) {
                 //Drop item on ground
                 player.getWorld().dropItemNaturally(player.getLocation(), inventoryContents[inventoryIndex]);
                 //Remove item from inventory
@@ -105,18 +123,13 @@ public class TownyCombatBattlefieldRoleUtil {
             }
         });
         //Send warning message(s)
-        if(invalidArmourIndexes.size() > 0) {
+        if(invalidInventoryIndexes.size() > 0) {
             Translatable errorMessage = Translatable.of("msg_warning_cannot_wear_this_armour");
             errorMessage.append(Translatable.of("msg_warning_how_to_view_and_change_role"));
             Messaging.sendErrorMsg(player, errorMessage);
         }
-        if(invalidWeaponIndexes.size() > 0) {
-            Translatable errorMessage = Translatable.of("msg_warning_cannot_wield_this_weapon");
-            errorMessage.append(Translatable.of("msg_warning_how_to_view_and_change_role"));
-            Messaging.sendErrorMsg(player, errorMessage);
-        }
     }
-    
+
     private static long getTimeUntilNextRoleChange(Resident resident) {
         long timeOfLastRoleChange = TownyCombatResidentMetaDataController.getLastBattlefieldRoleSwitchTime(resident);
         long timeOfNextRoleChange = timeOfLastRoleChange + (long)(TownyCombatSettings.getBattlefieldRolesMinimumTimeBetweenRoleChangesDays() * TimeMgmt.ONE_DAY_IN_MILLIS);

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatBattlefieldRoleUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatBattlefieldRoleUtil.java
@@ -43,6 +43,8 @@ public class TownyCombatBattlefieldRoleUtil {
     public static final List<Material> ironWeapons = Arrays.asList(Material.IRON_SWORD, Material.IRON_AXE);
     public static final List<Material> diamondWeapons = Arrays.asList(Material.DIAMOND_SWORD, Material.DIAMOND_AXE);
     public static final List<Material> netheriteWeapons = Arrays.asList(Material.NETHERITE_SWORD, Material.NETHERITE_AXE);
+    public static final List<Material> bows = Arrays.asList(Material.BOW);
+    public static final List<Material> crossbows = Arrays.asList(Material.CROSSBOW);
     public static final Map<Material, Set<BattlefieldRole>> armourBattlefieldRoleMap;
     public static final Map<Material, Set<BattlefieldRole>> weaponBattlefieldRoleMap;
 
@@ -58,8 +60,10 @@ public class TownyCombatBattlefieldRoleUtil {
         
         weaponBattlefieldRoleMap = new HashMap<>();
         addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, woodenWeapons, BattlefieldRole.LIGHT);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, bows, BattlefieldRole.LIGHT);
         addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, stoneWeapons, BattlefieldRole.MEDIUM);
         addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, ironWeapons, BattlefieldRole.MEDIUM);
+        addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, crossbows, BattlefieldRole.MEDIUM);
         addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, diamondWeapons, BattlefieldRole.HEAVY);
         addMaterialsToBattlefieldRoleMap(weaponBattlefieldRoleMap, netheriteWeapons, BattlefieldRole.HEAVY);
     }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -52,7 +52,7 @@ status_resident_content_light_super_potion_line: "&2Super Potion (1/day): &aTrue
 # Change-Battlefield-Role Warnings
 
 msg_warning_cannot_wear_this_armour: "&cArmor dropped, because you do not have the required Battlefield Role to wear it."
-msg_warning_cannot_wield_this_weapon: "&cWeapon dropped, because you do not have the required Battlefield Role to wield it."
+msg_warning_cannot_wield_this_weapon: "&cYou cannot wield this weapon in PVP, because you do not have the required Battlefield Role."
 msg_warning_how_to_view_and_change_role: " To view your Battlefield Role, type /resident. To change your Battlefield Role, type /tcm changerole <role>."
 msg_warning_cannot_change_role_now: "&cYou cannot change your battlefield role for another %s."
 


### PR DESCRIPTION
This PR does a few things:
- Added all known armour and weapons
- Refactored weapon restrictions so that:
  - Missile weapons will now not be dropped at any point, but will fail with a warning when fired
  - Melee weapons will now not be dropped at any point, but will fail with a warning when used
- Adds the passive ability of Light Troops: A +1 to potion effects

This feature is not yet complete, and future PR's and full testing will follow:
