### PR TITLE
Removed heavy armour passive slowness effect

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatBattlefieldRoleUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatBattlefieldRoleUtil.java
@@ -237,8 +237,6 @@ public class TownyCombatBattlefieldRoleUtil {
         Towny.getPlugin().getServer().getScheduler().runTask(Towny.getPlugin(), new Runnable() {
             public void run() {
                 livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, effectDurationTicks,0));
-                livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, effectDurationTicks,0));
-                livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, effectDurationTicks,-2));
             }
         });
     }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -60,9 +60,7 @@ status_resident_content_medium_super_potion_line: "&2Super Potion (%d/day): &aLi
 status_resident_content_heavy_line_armour: "&2Armor: &aDiamond, Netherite"
 status_resident_content_heavy_line_melee_weapons: "&2Melee Weapons: &aDiamond, Netherite"
 status_resident_content_heavy_line_missile_weapons: "&2Missile Weapons: &aNone"
-status_resident_content_heavy_line_passive_ability: "&2Passive Ability: &a+1 Resistance 1 when wearing armor"
-status_resident_content_heavy_line_disadvantage1: "&2Disadvantage: &aSlowness 1 when wearing armor"
-status_resident_content_heavy_line_disadvantage2: "&2Disadvantage: &aJumpBoost -2 when wearing armor"
+status_resident_content_heavy_line_passive_ability: "&2Passive Ability: &aResistance 1 when wearing armor"
 status_resident_content_heavy_line_disadvantage3: "&2Disadvantage: &aCannot use Potions of Swiftness"
 status_resident_content_heavy_super_potion_line: "&2Super Potion (%d/day): &aAbsorbtion V (3 minutes)"
     


### PR DESCRIPTION
- With current code those in heavy armour get Slowness 1
- However this disadvantage is not effective in PVP due to a limitation in vanilla minecraft, because soldiers can avoid it by jumping everywhere. Adding Jump Boost -2 stops the jumping but has a disastrous side effect that players cannot jump over single blocks.
- Previous version of TC tried to work around this issue, but so far no effective workaround has been found.
- This PR simply deletes the effect .... because in the context of TC4.0.0,  heavy troops are already the slowest troops on the field, and have no missile weapons, both of which are huge disadvantages, so I think the balance will be fine without the slowness effect.

Closes #81