### PR TITLE
Misc potion fixes & Lang file Updates

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -414,32 +414,26 @@ public class TownyCombatBukkitEventListener implements Listener {
 	public void on (BrewEvent event) {
 		if (!TownyCombatSettings.isTownyCombatEnabled())
 			return;
-		//Transmuted Potion
-		boolean potionsTransmuted = false;
-		ItemStack resultItemStack;
+		//Can't alter the new regen potions
 		if (TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() && TownyCombatSettings.isPotionTransmuterEnabed()) {
 			BrewerInventory brewerInventory = event.getContents();
-			if (brewerInventory.getIngredient() != null && brewerInventory.getIngredient().getType() == Material.GLISTERING_MELON_SLICE) {
-				//Replace ackward potions with special regen potions
-				for (int i = 0; i < brewerInventory.getContents().length; i++) {
-					resultItemStack = brewerInventory.getItem(i);
-					if (resultItemStack != null
-							&& resultItemStack.getType() == Material.POTION
-							&& resultItemStack.getItemMeta() != null
-							&& ((PotionMeta) resultItemStack.getItemMeta()).getBasePotionData().getType().equals(PotionType.AWKWARD)) {
-						brewerInventory.setItem(i, TownyCombatItemUtil.createTransmutedPotion(resultItemStack));
-						potionsTransmuted = true;
+			ItemStack resultItemStack;
+			for (int i = 0; i < brewerInventory.getContents().length; i++) {
+				resultItemStack = brewerInventory.getItem(i);
+				if (resultItemStack != null
+						&& resultItemStack.getType() == Material.POTION
+						&& resultItemStack.getItemMeta() != null
+						&& ((PotionMeta) resultItemStack.getItemMeta()).getCustomEffects().size() > 0
+						&& ((PotionMeta) resultItemStack.getItemMeta()).getCustomEffects().get(0).getType().equals(PotionEffectType.REGENERATION)) {
+					//Cancel Event. Reduce ingredient so the brew does not keep going indefinitely
+					if(brewerInventory.getIngredient() != null) {
+						brewerInventory.getIngredient().setAmount(brewerInventory.getIngredient().getAmount() - 1);
 					}
-				}
-				//If potions were transmuted, reduce ingredient, play sound and cancel event
-				if(potionsTransmuted) {
-					brewerInventory.getIngredient().setAmount(brewerInventory.getIngredient().getAmount() - 1);
-					event.getBlock().getWorld().playEffect(event.getBlock().getLocation(), Effect.BREWING_STAND_BREW, null);
 					event.setCancelled(true);
+					event.getBlock().getWorld().playEffect(event.getBlock().getLocation(), Effect.EXTINGUISH, null);
+					break;
 				}
 			}
-			
-
 		}
 	}
 	

--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatBukkitEventListener.java
@@ -37,6 +37,9 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.ProjectileSource;
 import org.spigotmc.event.entity.EntityDismountEvent;
@@ -382,18 +385,35 @@ public class TownyCombatBukkitEventListener implements Listener {
 	public void on (PrepareItemCraftEvent event) {
 		if (!TownyCombatSettings.isTownyCombatEnabled())
 			return;
-		if (!TownyCombatSettings.isNewItemsSpearEnabled() || !TownyCombatSettings.isNewItemsSpearNativeWeaponEnabled())
-			return;
-		if(event.getInventory().getResult() != null) {
-			if (event.isRepair()) {
-				//Cannot repair native spear
-				if (event.getInventory().getResult().getType() == Material.WOODEN_SWORD) {
-					event.getInventory().setResult(null);
+		ItemStack resultItemStack = event.getInventory().getResult();
+		if (resultItemStack!= null) {
+			//Native Spear
+			if (TownyCombatSettings.isNewItemsSpearEnabled() && TownyCombatSettings.isNewItemsSpearNativeWeaponEnabled()) {
+				if (event.isRepair()) {
+					//Cannot repair native spear
+					if (resultItemStack.getType() == Material.WOODEN_SWORD) {
+						event.getInventory().setResult(null);
+					}
+				} else {
+					//Craft native spear	
+					if (resultItemStack.getType() == Material.WOODEN_SWORD) {
+						event.getInventory().setResult(TownyCombatItemUtil.createNativeSpear());
+					}
 				}
-			} else {
-				//Craft native spear	
-				if (event.getInventory().getResult().getType() == Material.WOODEN_SWORD) {
-					event.getInventory().setResult(TownyCombatItemUtil.createNativeSpear());
+			}
+
+			//Transmuted Potion
+			if (TownyCombatSettings.isUnlockCombatForRegularPlayersEnabled() && TownyCombatSettings.isPotionTransmuterEnabed()) {
+				if (!event.isRepair()) {
+					if (resultItemStack.getType() == Material.POTION || resultItemStack.getType() == Material.SPLASH_POTION) {
+						if (resultItemStack.getItemMeta() != null) {
+							PotionMeta potionMeta = (PotionMeta) resultItemStack.getItemMeta();
+							PotionEffectType potionEffectType = potionMeta.getBasePotionData().getType().getEffectType();
+							if (potionEffectType != null && potionEffectType.equals(PotionEffectType.HEAL)) {
+								event.getInventory().setResult(TownyCombatItemUtil.createTransmutedPotion(resultItemStack));
+							}
+						}
+					}
 				}
 			}
 		}

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatItemUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatItemUtil.java
@@ -326,7 +326,7 @@ public class TownyCombatItemUtil {
         int transmutedPotionDurationTicks = TownyCombatSettings.getPotionTransmuterTransmutedPotionDurationSeconds() * 20;
         int sourcePotionAmplifier = oldPotionMeta.getBasePotionData().isUpgraded() ? 1: 0;
         int transmutedPotionAmplifier = sourcePotionAmplifier + TownyCombatSettings.getPotionTransmuterAmplificationAdjustment();
-        transmutedPotionAmplifier = Math.min(transmutedPotionAmplifier, 0);
+        transmutedPotionAmplifier = Math.max(transmutedPotionAmplifier, 0);
         PotionEffect potionEffect = new PotionEffect(PotionEffectType.REGENERATION, transmutedPotionDurationTicks, transmutedPotionAmplifier, false, false, true);
         newPotionMeta.addCustomEffect(potionEffect, true);
         //Set the adjusted potion meta into the itemstack

--- a/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatItemUtil.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/utils/TownyCombatItemUtil.java
@@ -290,30 +290,16 @@ public class TownyCombatItemUtil {
 
     public static void transmutePotionsInInventory(Player player) {
         PotionMeta oldPotionMeta;
-        PotionMeta newPotionMeta;
         int numTransmutedPotions = 0;
         for(ItemStack itemStack: player.getInventory().getContents()) {
             if(itemStack != null && (itemStack.getType() == Material.POTION || itemStack.getType() == Material.SPLASH_POTION)) {
                 oldPotionMeta = (PotionMeta) itemStack.getItemMeta();
                 if (oldPotionMeta != null && oldPotionMeta.getBasePotionData().getType() == PotionType.INSTANT_HEAL) {
-                    //Create a new potion meta object
-                    ItemStack dummyItemStack = new ItemStack(itemStack.getType());
-                    newPotionMeta = (PotionMeta) dummyItemStack.getItemMeta();
-                    //Set the potion name
-                    if(itemStack.getType() == Material.POTION) {
-                        newPotionMeta.setDisplayName(Translatable.of("transmuted_potion_name").translate(Locale.ROOT));
-                    } else {
-                        newPotionMeta.setDisplayName(Translatable.of("transmuted_potion_name_splash").translate(Locale.ROOT));
-                    }
-                    //Create a new potion effect
-                    int transmutedPotionDurationTicks = TownyCombatSettings.getPotionTransmuterTransmutedPotionDurationSeconds() * 20;
-                    int sourcePotionAmplifier = oldPotionMeta.getBasePotionData().isUpgraded() ? 1: 0;
-                    int transmutedPotionAmplifier = sourcePotionAmplifier + TownyCombatSettings.getPotionTransmuterAmplificationAdjustment();
-                    transmutedPotionAmplifier = Math.min(transmutedPotionAmplifier, 0);
-                    PotionEffect potionEffect = new PotionEffect(PotionEffectType.REGENERATION, transmutedPotionDurationTicks, transmutedPotionAmplifier, true, true, true);
-                    newPotionMeta.addCustomEffect(potionEffect, true);
-                    //Set the potion meta into the original itemstack
-                    itemStack.setItemMeta(newPotionMeta);
+                    //Create a new healing potion itemstack
+                    ItemStack transmutedPotion = createTransmutedPotion(itemStack);
+                    //Set the meta into the existing inventory item
+                    itemStack.setItemMeta(transmutedPotion.getItemMeta());
+                    //Increase the counter for messaging purposes
                     numTransmutedPotions++;
                 }
             }
@@ -321,5 +307,30 @@ public class TownyCombatItemUtil {
         if(numTransmutedPotions > 0) {
             Messaging.sendMsg(player, Translatable.of("potions_transmuted", numTransmutedPotions));
         }
+    }
+    
+    public static ItemStack createTransmutedPotion(ItemStack originalPotionItemStack) {
+        if(originalPotionItemStack.getItemMeta() == null) {
+            return new ItemStack(Material.GLASS_BOTTLE); //Edge case
+        }
+        PotionMeta oldPotionMeta = (PotionMeta) originalPotionItemStack.getItemMeta();
+        ItemStack newPotionItemStack = new ItemStack(originalPotionItemStack.getType());
+        PotionMeta newPotionMeta = (PotionMeta) newPotionItemStack.getItemMeta();
+        //Set the potion name
+        if(newPotionItemStack.getType() == Material.POTION) {
+            newPotionMeta.setDisplayName(Translatable.of("transmuted_potion_name").translate(Locale.ROOT));
+        } else {
+            newPotionMeta.setDisplayName(Translatable.of("transmuted_potion_name_splash").translate(Locale.ROOT));
+        }
+        //Create a new potion effect
+        int transmutedPotionDurationTicks = TownyCombatSettings.getPotionTransmuterTransmutedPotionDurationSeconds() * 20;
+        int sourcePotionAmplifier = oldPotionMeta.getBasePotionData().isUpgraded() ? 1: 0;
+        int transmutedPotionAmplifier = sourcePotionAmplifier + TownyCombatSettings.getPotionTransmuterAmplificationAdjustment();
+        transmutedPotionAmplifier = Math.min(transmutedPotionAmplifier, 0);
+        PotionEffect potionEffect = new PotionEffect(PotionEffectType.REGENERATION, transmutedPotionDurationTicks, transmutedPotionAmplifier, false, false, true);
+        newPotionMeta.addCustomEffect(potionEffect, true);
+        //Set the adjusted potion meta into the itemstack
+        newPotionItemStack.setItemMeta(newPotionMeta);
+        return newPotionItemStack;
     }
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -78,15 +78,15 @@ status_resident_content_medium_cavalry_super_potion: "&2Super Potion (%d/day): &
 status_resident_content_heavy_infantry_armour: "&2Armor: &aDiamond, Netherite"
 status_resident_content_heavy_infantry_melee_weapons: "&2Melee Weapons: &aDiamond, Netherite"
 status_resident_content_heavy_infantry_missile_weapons: "&2Missile Weapons: &aNone"
-status_resident_content_heavy_infantry_passive_ability: "&2Passive Ability: &aWhen armored, Resistance I"
+status_resident_content_heavy_infantry_passive_ability: "&2Passive Ability: &aResistance I (when armored)"
 status_resident_content_heavy_infantry_disadvantage: "&2Disadvantage: &aCannot use Potions of Swiftness"
 status_resident_content_heavy_infantry_super_potion: "&2Super Potion (%d/day): &aAbsorbtion V (3 mins)"
     
 status_resident_content_heavy_cavalry_armour: "&2Armor: &aDiamond, Netherite"
 status_resident_content_heavy_cavalry_melee_weapons: "&2Melee Weapons: &aDiamond, Netherite"
-status_resident_content_heavy_cavalry_missile_weapons: "&2Missile Weapons: &aCrossbow"
+status_resident_content_heavy_cavalry_missile_weapons: "&2Missile Weapons: &aCrossbow (when mounted)"
 status_resident_content_heavy_cavalry_passive_ability_A: "&2Passive Ability A: &aCavalry Power Shot Strength II"
-status_resident_content_heavy_cavalry_passive_ability_B: "&2Passive Ability B: &aWhen armored, Resistance I"
+status_resident_content_heavy_cavalry_passive_ability_B: "&2Passive Ability B: &aResistance I (when armored & mounted)"
 status_resident_content_heavy_cavalry_disadvantage: "&2Disadvantage: &aCannot use Potions of Swiftness"
 status_resident_content_heavy_cavalry_super_potion: "&2Super Potion (%d/day): &aAbsorbtion V (3 mins)"
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -128,7 +128,7 @@ spear_lore_line_1: "+%d Damage v.s. Cavalry"
 
 transmuted_potion_name: "Potion of Regeneration"
 transmuted_potion_name_splash: "Splash Potion of Regeneration"
-potions_transmuted: "&b%d potions of healing in your inventory were transmuted into potions of regeneration."
+potions_transmuted: "&b%d Potions of Healing in your inventory were transmuted into Potions of Regeneration."
 
 # Effect change errors
 


### PR DESCRIPTION
2 fixes
- Fixed an issue where Regen Potions II were not being created
- Fixed an issue where a Regen Potion could be made into an Uncraftable Potion using the brewing stand

1 lang file update
- Updated some status screen info

Tested