### PR TITLE
Ignore passable blocks in blockgitching prevention listeners

### DIFF
--- a/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatTownyEventListener.java
+++ b/src/main/java/io/github/townyadvanced/townycombat/listeners/TownyCombatTownyEventListener.java
@@ -10,6 +10,7 @@ import io.github.townyadvanced.townycombat.utils.TownyCombatBattlefieldRoleUtil;
 import io.github.townyadvanced.townycombat.utils.TownyCombatBlockUtil;
 import io.github.townyadvanced.townycombat.utils.TownyCombatItemUtil;
 import io.github.townyadvanced.townycombat.utils.TownyCombatMapUtil;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -33,6 +34,9 @@ public class TownyCombatTownyEventListener implements Listener {
         if(TownyCombatSettings.isTownyCombatEnabled() 
 	        	&& TownyCombatSettings.isBlockGlitchingPreventionEnabled()
     	    	&& event.isCancelled()) {
+			Block block = event.getBlock();
+			if (block.isPassable()) return;
+
             TownyCombatBlockUtil.applyBlockGlitchingPrevention(event.getPlayer());
         }
 	}
@@ -42,6 +46,9 @@ public class TownyCombatTownyEventListener implements Listener {
         if(TownyCombatSettings.isTownyCombatEnabled() 
         		&& TownyCombatSettings.isBlockGlitchingPreventionEnabled()
         		&& event.isCancelled()) {
+			Block block = event.getBlock();
+			if (block.isPassable() && !block.isLiquid()) return;
+
             TownyCombatBlockUtil.applyBlockGlitchingPrevention(event.getPlayer());
         }
 	}


### PR DESCRIPTION
This PR returns early in the TownyDestroyEvent and TownyBuildEvent listeners if the block in question returns true for an `isPassable` check.

The build listener additionally checks the block also isn't liquid to make sure that the user can't use water/lava to blockglitch.

The intention of this is to ignore blocks that don't make blockglitching possible and are annoying when you accidentally break such as grass, they are mostly blocks that instantly break too making it a very common occurrence.